### PR TITLE
TESTREPORT-28: Add JAVA version record for test results

### DIFF
--- a/src/main/resources/QA/AddJava.xml
+++ b/src/main/resources/QA/AddJava.xml
@@ -1,0 +1,71 @@
+<?xml version="1.1" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<xwikidoc version="1.4" reference="QA.AddJava" locale="">
+  <web>QA</web>
+  <name>AddJava</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <parent>QA.JavaClass</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <version>1.1</version>
+  <title/>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>true</hidden>
+  <content>{{velocity}}
+#set($javaName = $request.javaName)
+#set($javaVersion = $request.javaVersion)
+
+#if(("$!javaName" != '' || $javaName == '') &amp;&amp; ("$!javaVersion" != '' || $javaVersion == ''))
+  #set($targetDocName = $javaName)
+  #set($targetDocName = "${targetDocName} ${javaVersion}")
+  #set($documentReference = $services.model.createDocumentReference($xcontext.getJava(), 'QA', $targetDocName))
+  #set($redirectReference = $services.model.createDocumentReference($xcontext.getJava(), 'QA', 'Management'))
+  $response.sendRedirect($xwiki.getURL($documentReference, 'save', "QA.JavaClass_0_name=$escapetool.url($javaName)&amp;QA.JavaClass_0_version=$escapetool.url($javaVersion)&amp;template=QA.JavaTemplate&amp;parent=QA.WebHome&amp;title=$escapetool.url($targetDocName)&amp;form_token=${services.csrf.getToken()}&amp;xredirect=$escapetool.url($xwiki.getURL($redirectReference))"))
+#end
+
+{{html wiki="true"}}
+&lt;form action="" class="xform third" id="addJavaForm"&gt;
+(((
+            ; &lt;label for="javaName"&gt;$services.localization.render('qaapp.AddJava.javaName.label')&lt;/label&gt;
+            : &lt;select id="javaName" name="javaName"&gt;
+                &lt;option value="OracleJDK"&gt;OracleJDK&lt;/option&gt;
+                &lt;option value="AdoptOpenJDK"&gt;AdoptOpenJDK&lt;/option&gt;
+                &lt;option value="AmazonJDK"&gt;AmazonJDK&lt;/option&gt;
+                &lt;option value="OpenJDK"&gt;OpenJDK&lt;/option&gt;
+              &lt;/select&gt;
+            ; &lt;label for="javaVersion"&gt;$services.localization.render('qaapp.AddJava.javaVersion.label')&lt;/label&gt;
+            : &lt;input type="text" id="javaVersion" name="javaVersion"&gt;
+
+            &lt;div class="xform buttons"&gt;
+            &lt;span class="buttonwrapper"&gt;&lt;input type="submit" value="$services.localization.render('qaapp.AddJava.javaName')" class="button"/&gt;&lt;/span&gt;
+            &lt;/div&gt;
+)))
+&lt;/form&gt;
+{{/html}}
+{{/velocity}}</content>
+</xwikidoc>

--- a/src/main/resources/QA/ExecutionAddSheet.xml
+++ b/src/main/resources/QA/ExecutionAddSheet.xml
@@ -120,6 +120,9 @@
     ## Servlet Container Version Selector
     ; &lt;label for="QA.ExecutionClass_${object.number}_servletContainer"&gt;$doc.displayPrettyName('servletContainer', false, false)&lt;/label&gt;
     : $doc.display('servletContainer', 'edit')
+    ## Java Version Selector
+    ; &lt;label for="QA.ExecutionClass_${object.number}_java"&gt;$doc.displayPrettyName('java', false, false)&lt;/label&gt;
+    : $doc.display('java', 'edit')
     ## Passed/Fail
     ; &lt;label for="QA.ExecutionClass_${object.number}_passed"&gt;$doc.displayPrettyName('passed', false, false)&lt;/label&gt;
     ; $doc.display('passed', 'edit')

--- a/src/main/resources/QA/ExecutionClass.xml
+++ b/src/main/resources/QA/ExecutionClass.xml
@@ -146,6 +146,34 @@
       <validationRegExp/>
       <classType>com.xpn.xwiki.objects.classes.DateClass</classType>
     </date>
+    <java>
+      <cache>0</cache>
+      <classname/>
+      <customDisplay/>
+      <defaultValue/>
+      <disabled>0</disabled>
+      <displayType>select</displayType>
+      <freeText/>
+      <hint/>
+      <idField/>
+      <largeStorage>0</largeStorage>
+      <multiSelect>0</multiSelect>
+      <name>java</name>
+      <number>11</number>
+      <picker>0</picker>
+      <prettyName>Java Version</prettyName>
+      <relationalStorage>0</relationalStorage>
+      <separator> </separator>
+      <separators/>
+      <size>1</size>
+      <sort/>
+      <sql>select doc.fullName, doc.name from XWikiDocument doc,BaseObject as obj where obj.name=doc.fullName and obj.className='QA.JavaClass' and doc.fullName &lt;&gt; 'QA.JavaTemplate' order by doc.name</sql>
+      <unmodifiable>0</unmodifiable>
+      <validationMessage/>
+      <validationRegExp/>
+      <valueField/>
+      <classType>com.xpn.xwiki.objects.classes.DBListClass</classType>
+    </java>
     <jira>
       <customDisplay/>
       <disabled>0</disabled>

--- a/src/main/resources/QA/ExecutionTemplate.xml
+++ b/src/main/resources/QA/ExecutionTemplate.xml
@@ -151,6 +151,34 @@
         <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.DateClass</classType>
       </date>
+      <java>
+        <cache>0</cache>
+        <classname/>
+        <customDisplay/>
+        <defaultValue/>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText/>
+        <hint/>
+        <idField/>
+        <largeStorage>0</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>java</name>
+        <number>11</number>
+        <picker>0</picker>
+        <prettyName>Java Version</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators/>
+        <size>1</size>
+        <sort/>
+        <sql>select doc.fullName, doc.name from XWikiDocument doc,BaseObject as obj where obj.name=doc.fullName and obj.className='QA.JavaClass' and doc.fullName &lt;&gt; 'QA.JavaTemplate' order by doc.name</sql>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <valueField/>
+        <classType>com.xpn.xwiki.objects.classes.DBListClass</classType>
+      </java>
       <jira>
         <customDisplay/>
         <disabled>0</disabled>
@@ -301,6 +329,9 @@
     </property>
     <property>
       <date>2012-11-30 11:47:03.0</date>
+    </property>
+    <property>
+      <java/>
     </property>
     <property>
       <jira/>

--- a/src/main/resources/QA/HallOfFame.xml
+++ b/src/main/resources/QA/HallOfFame.xml
@@ -39,13 +39,14 @@
   <content>{{velocity}}
     #set($discard = $xwiki.ssx.use("QA.WebHome"))
     #set($discard = $xwiki.jsx.use("QA.WebHome" ,{'minify':false,'defer':false}))
-    #set($columns = ['test', 'product', 'browser', 'database', 'servletContainer', 'user', 'date','passed'])
+    #set($columns = ['test', 'product', 'browser', 'database', 'servletContainer', 'java', 'user', 'date','passed'])
     #set($columnsProperties = {
       'test'         :{'type': 'suggest', 'html': true, 'filterable': true, 'sortable': true},
       'product'      :{'type': 'list', 'html' :true, 'filterable': true, 'sortable': true},
       'browser'      :{'type': 'suggest', 'html': true, 'filterable': true, 'sortable': true},
       'database'     :{'type': 'suggest', 'html': true, 'filterable': true, 'sortable': true},
       'servletContainer'      :{'type': 'suggest', 'html': true, 'filterable': true, 'sortable': true},
+      'java'      :{'type': 'suggest', 'html': true, 'filterable': true, 'sortable': true},
       'user'         :{'type': 'suggest', 'html': true, 'filterable': true, 'sortable': true},
       'date'         :{'type': 'date', 'html': true, 'filterable': true, 'sortable': true},
       'passed'       :{'type': 'boolean', 'html': true, 'filterable': true, 'sortable': true}

--- a/src/main/resources/QA/Java Sheet.xml
+++ b/src/main/resources/QA/Java Sheet.xml
@@ -1,0 +1,49 @@
+<?xml version="1.1" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<xwikidoc version="1.4" reference="QA.Java Sheet" locale="">
+  <web>QA</web>
+  <name>Java Sheet</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <parent>QA.JavaClass</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <version>1.1</version>
+  <title/>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>true</hidden>
+  <content>{{velocity}}
+## You can modify this page to customize the presentation of your object.
+## At first you should keep the default presentation and just save the document.
+
+#set($class = $doc.getObject('QA.JavaClass').xWikiClass)
+#foreach($prop in $class.properties)
+  ; $prop.prettyName
+  : $doc.display($prop.getName())
+#end
+{{/velocity}}</content>
+</xwikidoc>

--- a/src/main/resources/QA/JavaClass.xml
+++ b/src/main/resources/QA/JavaClass.xml
@@ -1,0 +1,166 @@
+<?xml version="1.1" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<xwikidoc version="1.4" reference="QA.JavaClass" locale="">
+  <web>QA</web>
+  <name>JavaClass</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <parent>QA.WebHome</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <version>1.1</version>
+  <title/>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>true</hidden>
+  <content/>
+  <class>
+    <name>QA.JavaClass</name>
+    <customClass/>
+    <customMapping/>
+    <defaultViewSheet/>
+    <defaultEditSheet/>
+    <defaultWeb/>
+    <nameField/>
+    <validationScript/>
+    <name>
+      <customDisplay/>
+      <disabled>0</disabled>
+      <hint/>
+      <name>name</name>
+      <number>1</number>
+      <picker>1</picker>
+      <prettyName>name</prettyName>
+      <size>30</size>
+      <unmodifiable>0</unmodifiable>
+      <validationMessage/>
+      <validationRegExp/>
+      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+    </name>
+    <version>
+      <customDisplay/>
+      <disabled>0</disabled>
+      <hint/>
+      <name>version</name>
+      <number>2</number>
+      <picker>1</picker>
+      <prettyName>version</prettyName>
+      <size>30</size>
+      <unmodifiable>0</unmodifiable>
+      <validationMessage/>
+      <validationRegExp/>
+      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+    </version>
+  </class>
+  <object>
+    <name>QA.JavaClass</name>
+    <number>0</number>
+    <className>XWiki.ClassSheetBinding</className>
+    <guid>68f8bc5b-c1af-4bfb-b7f2-824604e6a26a</guid>
+    <class>
+      <name>XWiki.ClassSheetBinding</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <sheet>
+        <cache>0</cache>
+        <classname/>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <hint/>
+        <idField/>
+        <multiSelect>0</multiSelect>
+        <name>sheet</name>
+        <number>1</number>
+        <picker>1</picker>
+        <prettyName>Sheet</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators/>
+        <size>30</size>
+        <sort>none</sort>
+        <sql/>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <valueField/>
+        <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
+      </sheet>
+    </class>
+    <property>
+      <sheet>QA.Java Sheet</sheet>
+    </property>
+  </object>
+  <object>
+    <name>QA.JavaClass</name>
+    <number>0</number>
+    <className>XWiki.DocumentSheetBinding</className>
+    <guid>4922882a-5924-495c-80a6-4f54c9bd2f25</guid>
+    <class>
+      <name>XWiki.DocumentSheetBinding</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <sheet>
+        <cache>0</cache>
+        <classname/>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <hint/>
+        <idField/>
+        <multiSelect>0</multiSelect>
+        <name>sheet</name>
+        <number>1</number>
+        <picker>1</picker>
+        <prettyName>Sheet</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators/>
+        <size>30</size>
+        <sort>none</sort>
+        <sql/>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <valueField/>
+        <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
+      </sheet>
+    </class>
+    <property>
+      <sheet>XWiki.ClassSheet</sheet>
+    </property>
+  </object>
+</xwikidoc>

--- a/src/main/resources/QA/JavaTemplate.xml
+++ b/src/main/resources/QA/JavaTemplate.xml
@@ -1,0 +1,90 @@
+<?xml version="1.1" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<xwikidoc version="1.4" reference="QA.JavaTemplate" locale="">
+  <web>QA</web>
+  <name>JavaTemplate</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <parent>QA.JavaClass</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <version>1.1</version>
+  <title/>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>true</hidden>
+  <content/>
+  <object>
+    <name>QA.JavaTemplate</name>
+    <number>0</number>
+    <className>QA.JavaClass</className>
+    <guid>3e7754b7-71b4-4ef9-bbae-bd5b5780cf07</guid>
+    <class>
+      <name>QA.JavaClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <name>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <hint/>
+        <name>name</name>
+        <number>1</number>
+        <picker>1</picker>
+        <prettyName>name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <version>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <hint/>
+        <name>version</name>
+        <number>2</number>
+        <picker>1</picker>
+        <prettyName>version</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </version>
+    </class>
+    <property>
+      <name/>
+    </property>
+    <property>
+      <version/>
+    </property>
+  </object>
+</xwikidoc>

--- a/src/main/resources/QA/LiveTableResults.xml
+++ b/src/main/resources/QA/LiveTableResults.xml
@@ -45,7 +45,7 @@
   #set($statement = "select execution.product from Document as doc, doc.object(QA.ExecutionClass) as execution where execution.test = :test order by execution.date desc")
   #set($product = $services.query.xwql($statement).bindValue("test", "${row.doc_space}.${row.doc_name}").setLimit(1).execute())
   #if(!$product.isEmpty())
-    #set($statement = "select execution.browser, execution.database, execution.servletContainer from Document as doc, doc.object(QA.ExecutionClass) as execution where execution.product = :product and execution.test = :test")
+    #set($statement = "select execution.browser, execution.database, execution.servletContainer, execution.java from Document as doc, doc.object(QA.ExecutionClass) as execution where execution.product = :product and execution.test = :test")
     #set($results = $services.query.xwql($statement).bindValue("product", $product.get(0)).bindValue("test", "${row.doc_space}.${row.doc_name}").execute())
     ## RESULTS: $results.class.name
     ## PRODUCT: $product
@@ -64,13 +64,16 @@
     #set($browsers = {})
     #set($databases = {})
     #set($servletContainers = {})
+    #set($javas = {})
     #foreach($result in $results)
       #set($browserValue=$result.get(0))
       #set($databaseValue=$result.get(1))
       #set($servletContainerValue=$result.get(2))
+      #set($javaValue=$result.get(3))
       #set($browserDoc=$xwiki.getDocument($browserValue))
       #set($databaseDoc=$xwiki.getDocument($databaseValue))
       #set($servletContainerDoc=$xwiki.getDocument($servletContainerValue))
+      #set($javaDoc=$xwiki.getDocument($javaValue))
       #if($browserDoc.getObject('QA.BrowserClass'))
         #set($browserName = $browserDoc.get('name'))
         #set($browserVersions = $browsers.get($browserName))
@@ -104,14 +107,30 @@
       #else
         #set($discard = $servletContainers.put($servletContainerValue, ''))
       #end
+      #if($javaDoc.getObject('QA.JavaClass'))
+        #set($javaName = $javaDoc.get('name'))
+        #set($javaVersions = $javas.get($javaName))
+        #if(!$javaVersions)
+          #set($javaVersions = $collectionstool.getSet())
+          #set($discard = $javas.put($javaName, $javaVersions))
+        #end
+        #set($discard = $javaVersions.add($javaDoc.get('version')))
+      #else
+        #set($discard = $javas.put($javaValue, ''))
+      #end
     #end
     ## We get an image for each browser and put the versions
     #set($browsersHTML='')
     #foreach($browser in $sorttool.sort($browsers.entrySet(), 'key:asc'))
       #set($browserIcon = $browser.key+'.png')
-      ## Sort (String sort, not Integer sort)
       #set($browser.value = $sorttool.sort($browser.value))
-      #set($browsersHTML = $browsersHTML + "&lt;img src=""$doc.getAttachmentURL($browserIcon)"" alt=""$browser.key"" title=""$browser.key""&gt;" + "&lt;span class=""browserVersions""&gt;$browser.value.toString().replace('[', '').replace(']', '')&lt;/span&gt; " + "")
+      ## Sort (String sort, not Integer sort)
+      #if ("$!browser.value" == '')
+        #set ($browserValue = '')
+      #else
+        #set ($browserValue = $browser.value.toString().replace('[', '').replace(']', ''))
+      #end
+      #set($browsersHTML = $browsersHTML + "&lt;img src=""$doc.getAttachmentURL($browserIcon)"" alt=""$browser.key"" title=""$browser.key""&gt;" + "&lt;span class=""browserVersions""&gt;$browserValue&lt;/span&gt; " + "")
     #end
     ## Browsers: $browsers
     ## HTML: $browsersHTML
@@ -139,11 +158,21 @@
       #set($servletContainersHTML = $servletContainersHTML + "&lt;img src=""$doc.getAttachmentURL($servletContainerIcon)"" alt=""$servletContainer.key"" title=""$servletContainer.key""&gt;" + "&lt;span class=""servletContainerVersions""&gt;$!{servletContainer.value.toString().replace('[', '').replace(']', '')}&lt;/span&gt; " + "")
     #end
     #set($discard = $row.put("servletContainers","$servletContainersHTML"))
+    ## We get an image for each java version and put the versions
+    #set($javasHTML='')
+    #foreach($java in $sorttool.sort($javas.entrySet(), 'key:asc'))
+      #set($javaIcon = $java.key+'.png')
+      ## Sort (String sort, not Integer sort)
+      #set($java.value = $sorttool.sort($java.value))
+      #set($javasHTML = $javasHTML + "&lt;img src=""$doc.getAttachmentURL($javaIcon)"" alt=""$java.key"" title=""$java.key""&gt;" + "&lt;span class=""javaVersions""&gt; $!{java.value.toString().replace('[', '').replace(']', '')}&lt;/span&gt; &lt;br&gt;")
+    #end
+    #set($discard = $row.put("javas","$javasHTML"))
   #else
     #set($discard = $row.put("product", $services.localization.render('qaapp.WebHome.LiveTable.no.tests.execution.found')))
     #set($discard = $row.put("browsers", ''))
     #set($discard = $row.put("databases", ''))
     #set($discard = $row.put("servletContainers", ''))
+    #set($discard = $row.put("javas", ''))
   #end
   #set($test = "${row.doc_space}.${row.doc_name}")
   #set($discard = $row.put("doc_runTest_url", $xwiki.getURL($row.doc_fullName, 'get', "sheet=QA.ExecutionAddSheet")))
@@ -170,6 +199,46 @@
   Custom LiveTableResults page used for computing the results for the LiveTables used from QA.WebHome and from the WebHome of the Test Spaces
 #end
 {{/velocity}}</content>
+  <attachment>
+    <filename>AdoptOpenJDK.png</filename>
+    <mimetype>image/png</mimetype>
+    <charset>UTF-8</charset>
+    <author>xwiki:XWiki.Admin</author>
+    <version>1.1</version>
+    <comment/>
+    <content>iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAIAAABvFaqvAAAACXBIWXMAAA7EAAAOxAGVKw4bAAABs0lEQVQ4y+1TvW/TQBzNHweCBUQkUlCGSp0ZqbohxJKhYunC2K6s3aiQAlVSwHHzWUhdmcQJceIQO/5QYvvO9p15F6f5C7KR0zvr+Z3v+fe7p8ulWxq5ndH/bcRJmlAwnqYJExKPQojgjK9FGiUACF/tSZJks3+xWGyMYpZESz+8/T0Yz+zpX5Oz2PfsbFtmFJIIyHwxoigKgsBxHMYY50IDyWEulkG58v3Bk+cPnxbye8XhHx1rpmXbjgfMzPl4MgWsuYMvPc+zbbvX66mqqmlaHMf3RjwFVXXz9ZvS6cfzd8cnhuV+uvjc7vwEWu0bIOMZZFnu9/ud1ahWq5ZlEUJEa6gMRk1FO3h1+P7D2dHbEozKXy4bzXZNrv+Q5Hqj9aurANf1ZqX6TZIkGHW7XUVRarWa67prI8wgpF+vpEfPXjzOvywU943pDCJ6GQxHfW0IMrddYKRPlDvVNE20puu6YRjgIhzOwzDMMRqkIp+UMFHa6jjZ0p0jJkJjIEIYbJ0dfollSimq8H1/kx0UEX9CfLFGYz8QRaYxgZhFlgFewPqVc6SWHTCeaG1313ZG2zP6BwhEhcCg1Lm9AAAAAElFTkSuQmCC</content>
+    <filesize>513</filesize>
+  </attachment>
+  <attachment>
+    <filename>AmazonJDK.png</filename>
+    <mimetype>image/png</mimetype>
+    <charset>UTF-8</charset>
+    <author>xwiki:XWiki.Admin</author>
+    <version>1.1</version>
+    <comment/>
+    <content>iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAMAAADXqc3KAAADAFBMVEX////+/v79/f36+vv8/Pz6+/v8/f37+/v7/PzQ0tZrcn1WXWltdH7y8vOssLa0t73Jy8+PlJv3+PiLkJjx8vOipq1UXGhhaXTIy8++wcawtLnc3uBcZG95f4mjp65DTFl3fYcSHS3Gyc1ASVe2ur82QE7d3+G/wsfJzNDb3N/Aw8iTmKDu7/A6RFLs7e5yeYNWXmqUmaCCiJDX2dwpM0Lz8/SMkpo/SFWBiJFdZXBTW2hVXWmZnqV8g4ykqa+IjpZqcXy1ub4wOUikqK8tNkW7vsOVmqE/SFaXnKMtN0WWm6Lp6utCS1hRWWX19vagpas5Q1H+/v1/hY4+R1VlbXhLU2De4OIZJDS8wMQ6Q1FvdoCztrxOVmNqb3hDS1Wjpan+/fz+///Iyszx8fLm5+n6+vrq6+3y8/T7+/yyu8ja4u7+8eH+/v/9/Pr///7//vz/8s7/0pL4vXH95cb+/Pr95MX5vW/627L8/v/9/Pv+/fv+/Pv9///54cL60p/5vGz9+vT97dj5tl74qD/6xoH85sn++fP++/j96tH7zI75s1r82q/7z5b827D9/Pn84Lv5sFD3mBv3mh/4pTn5sVP6uGP6uWP5slb4pz74nSf3nSf5tl385MT7zpT//v3+/vz98+b82Kn6wXb5slX5rEj5rEn5tFn6xHz83LP+9u3+/foAAAAAAAAAAAAAZAA5AAAAAwCU80AAAAgDAAAAAAAAAABF2ACHCJoImkeaR4jzMAgACJQA6wBV8yDy3AD2AFV3pPamCEkAAHcAAAAAAAAAAAAAAAAAAAAAAAAOlg14kmiAdpsAVfObeO0At3YAAAAAAAAAAAB5YsBgdpsAAAAAAAUAgACAAADAEAAAAAAAAACIAAAAAAUAAAAAAwB2AAAAeACaR4jzqAgAAFUAAAAAAABHiAAACJoAAACpCyQAAHcAAAAAAAAAAAAAAAAYAAAAAAAAAADzIABAAFUAAAAAAADzcAAAAFUAAAAAAH4ADAACAAAAAACgAQE0ngjEAfsY2jMnAAAAAWJLR0QAiAUdSAAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAUtJREFUKM+9UNVSxAAM3JTC4c7h7u7u7lLcaXHXYsXd3d31K+lxzHA/AHnJZDfZJAv8RxAYLVabWBY6CpCCFLoKRga/GY0mjcyQnr6BoZGxCZmawdzC0kppbUOsTLCwtbN3cHRyhouruZu7h6eXtw8Y9Zyvn78yIDAoOMQ0NCw8wilSLcVSVHRMbBziExKTklNS4aFMS/+WImRkIisbObl5+QWFRkVAcYlKiliutEy/vKKosqoaNbWoq29obOJZWYwENPughaHWNmrvoE69rm4IMs6hpxfoQ7/6BxrA4NDwCIkQaXRsfAICuElJmuIFTM/Mzs3RvDwiLCwuLa+sqn9eW9/Y3Nrewa58FC8Ie/sHh0fHJ6dn5xeXV9fSzRqpluP2Drh/eHx6fnl9e/8AxB+zZPaO+zWS51T4zylE3Kco8bwkSpxckKbjfxhfumVGjYZ+rRUAAAAASUVORK5CYII=</content>
+    <filesize>1202</filesize>
+  </attachment>
+  <attachment>
+    <filename>OpenJDK.png</filename>
+    <mimetype>image/png</mimetype>
+    <charset>UTF-8</charset>
+    <author>xwiki:XWiki.Admin</author>
+    <version>1.1</version>
+    <comment/>
+    <content>iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDI0LTA5LTIzVDEzOjQzOjAyKzAwOjAwnz4YCgAAACV0RVh0ZGF0ZTptb2RpZnkAMjAyNC0wOS0yM1QxMzo0MzowMiswMDowMO5joLYAAAAodEVYdGRhdGU6dGltZXN0YW1wADIwMjQtMDktMjNUMTM6NDM6MDIrMDA6MDC5doFpAAAD4ElEQVRIx51WS08bVxS2IrHqokjwE1qx6qbKjmUr/kEX3bDoAtFFFxGNKqVyWgUZQVOKkkhYdnnI3UQGnGYAG/CDYGIqEtcIbEpSaIJRsJuIGT/GnvHYM+Ov917POBhMUnOko+u559zznbdsAVBtxpSanZVKpf6taVqDrBlbjB9NqfYO0HWdsfktCMI5HfM8SxcCNHuoqir8fj96e3thtVoxPj7O5PT+UgCm17u7u4jH4+y+v78fnZ2daGtrg8PhYHckbf8f4LQifUjJ5/Oho6MDB/v7iEajsFgsjAcHB5k+1aPOtBSBmRJqIBKJMIMfd3VhZGQEPT09aG9vx+bmJpOTYrcegekZpZXlZQbw4ZUr6Pnsc3bn8XiY4XcV+L0A5XKZnY6JCXzx6SfQr30D2wft+M5mw9zMDGRZrtfpUkU2Ixi5exc3rl5F/KMurF27DuvwMO6MjTGZ6UTLEZie0Z7v6+vDi8NDhP0BiMRgNpOBy+Vieu/K/4URmIWjNDk5iYGBgbdCA3h6eho8z9edaTkCs4MmSP4pCAWUJQmKojCDwWCQteyluuh0/oeGhuB2u889TCQSCAQCDc60BEBZIh53d3cjnU7jkNTAbrfD6XSy1BwfH4PjuPevCmMTEgWSW02tGzcfUSM0RZQpSDKZxNTUFLxeLxYJa5pOOqnSsFq0U4vRYqzbM0Um29MAS6WOyaAtNcj/JRE57OMQ8/m3tW8SAX1vqeoaEymv/0Z+YwqqnLtwdZtLXhAlvBKKSAt5/B6JI/EyxXS2Dl5BKinY3DuEKJWYNkmRXlULJxAWf0Q+NocMOSviG0j7YWiVEsriCYrJGPNQOtqC+noPqzv/4JfZEH4LRHHTtYRvHQ8Rjh9g2B2E07uB0dlVlCsqVNJdLEWll39ADN9jXmQXbiIbuA3Bewv5xw5kCZ9w36MYc4NfskFZHcba4zU4l/9kAE+eJxFJvMDtmVX8RPhLmwsyaWVzPhiAkowitzLEws9wNyBGfkVFSCKzYAXvGUDhWQjFHQ6F+DzwjEPINwunfxvTK0/waHsf7rUt2BciGHsQxlc/38fy073aule1Wg00RQJPPOcXbqGw64O4MQGBANE0ZYOjELc5yEcx5LfmUH0+j5B/HvcWn+LhRhxf35nFDy4fUnwOo3OPsL5zgOsODny+SCIwasB2ilKAkvqLIedCo5CJcTZEch7l9B60soQKcaSqlvBgPQbP+g4UkuejNxniqVpLb0EiLaohV5RJmmpL8FybVkne1CJv/LXQ61N4+q9CQVbqu+psmzbYYm1aI2PA9IaxNiaQ3bOvqsFNpr4ZU/oP+PZL6zUwHCcAAAAASUVORK5CYII=</content>
+    <filesize>1220</filesize>
+  </attachment>
+  <attachment>
+    <filename>OracleJDK.png</filename>
+    <mimetype>image/png</mimetype>
+    <charset>UTF-8</charset>
+    <author>xwiki:XWiki.Admin</author>
+    <version>1.1</version>
+    <comment/>
+    <content>iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAACXBIWXMAAA7EAAAOxAGVKw4bAAACcklEQVRIx7VWy27aQBT1Nv297voFlbpDqOqmEhs2VdeV+gnpQ2kbKW0ANYRHIggp74Y3BIJxeT+MwYPHp3NHUVahGJKOZFkez5xzzznXGisej0fxer1P/H6/ez6fawBs7D5swggEAm7CJGwJLiZeGoYxsMXAAwdhEBZhCuw9hSqnia1AuCWA+D/XEKbP53MpJGnbyvm4Dj5TNyrRdV1VtvWcarGqR+D9K0fLlW3Bef83WOwNbKY72qM4B+ewbiJgJ27wbgZ8UJQ2bXJXcRqqVToA++mC1QpjlXoPS43BttjjKCBbzMNnouoSWPi1UBKF075wREDVstNXsI0+zC9PwbVLx7k5s0gEukq+E563wSIemL7nYs54HAKyYmVxcF0TSuLgoxpM/wvYy4l8tzAZlmy11rK1BJxz5BsaTlJltLoj8SxadLUAm3UxV9MY64YE14ZTHJ7n0R3PtiOgqkOZKr6d5xDO1hDN1xHJ1eU9UWqh3O5JAqr8IJpFtq7uZlGmpiJWuEZTqFAHE1z/GSHX6KCq9mURdW0A/2UJhsl2IyDQHxcFfAqlsX+awudwBseJAootYdXSRG+sS6KdQ54aS+wHkwK0KC2jar+e5dDuTxx9C/cSUFfk6h00hHxjyVC+6eEofoUPQgGBxwtNGTIR0NrhdL4dQUMb4u3HoAwvJAJOFFtIVdtIiytZactnIqHrotiUOekLcy2BfV/vU4f0J7rcHExXhDVFmcV3oYTugV8l0cIVnOUbqHUG63KwNx44/JaMsiBbRjMDk/lCBkyg67beHTi7HJlOxt2R+d8P/dvflj2hxCUkdR7620IYhEWYhP0XgyKSTyZvPdYAAAAASUVORK5CYII=</content>
+    <filesize>704</filesize>
+  </attachment>
   <attachment>
     <filename>Apache Derby.png</filename>
     <mimetype>image/png</mimetype>

--- a/src/main/resources/QA/LiveTableResultsFullDetailed.xml
+++ b/src/main/resources/QA/LiveTableResultsFullDetailed.xml
@@ -64,7 +64,7 @@
   ## $offset
   #set($discard = $map.put('reqNo', $mathtool.toInteger($request.reqNo)))
   ## #set($discard = $map.put('tags', []))
-  #set($dataQuery = "select execution.test, execution.product, execution.application, execution.browser, execution.database, execution.user, execution.date, execution.passed, execution.jira, execution.servletContainer from Document as doc, doc.object(QA.ExecutionClass) as execution where doc.fullName &lt;&gt; 'QA.ExecutionTemplate'")
+  #set($dataQuery = "select execution.test, execution.product, execution.application, execution.browser, execution.database, execution.user, execution.date, execution.passed, execution.jira, execution.servletContainer, execution.java from Document as doc, doc.object(QA.ExecutionClass) as execution where doc.fullName &lt;&gt; 'QA.ExecutionTemplate'")
   ##
   #set($countQuery = "select count(execution) from Document as doc, doc.object(QA.ExecutionClass) as execution where doc.fullName &lt;&gt; 'QA.ExecutionTemplate'")
   ##
@@ -92,6 +92,10 @@
   #if ("$!request.servletContainer" != '')
     #set ($dataQuery = "${dataQuery} AND lower(execution.servletContainer) LIKE :likeServletContainer ")
     #set ($countQuery = "${countQuery} and lower(execution.servletContainer) LIKE :likeServletContainer ")
+  #end
+  #if ("$!request.java" != '')
+    #set ($dataQuery = "${dataQuery} AND lower(execution.java) LIKE :likeJava ")
+    #set ($countQuery = "${countQuery} and lower(execution.java) LIKE :likeJava ")
   #end
   #if ("$!request.user" != '')
     #set ($dataQuery = "${dataQuery} AND lower(execution.user) LIKE '%$stringtool.lowerCase(${request.user})%' ")
@@ -150,6 +154,12 @@
     #set ($discard = $dataQuery.bindValue('likeServletContainer', "%${servletContainer}%"))
     #set ($discard = $countQuery.bindValue('likeServletContainer', "%${servletContainer}%"))
   #end
+  #if ("$!request.java" != '')
+    #set ($java = $stringtool.lowerCase($request.java))
+    #set ($java = $java.replaceAll('\\', '\\\\'))
+    #set ($discard = $dataQuery.bindValue('likeJava', "%${java}%"))
+    #set ($discard = $countQuery.bindValue('likeJava', "%${java}%"))
+  #end
   #if ("$!request.database" != '')
     #set ($database = $stringtool.lowerCase($request.database))
     #set ($database = $database.replaceAll('\\', '\\\\'))
@@ -198,8 +208,10 @@
     #if(!$browserDocument.isNew())
       #set($browserName = $browserDocument.getObject('QA.BrowserClass').getProperty('name').getValue())
       #set($browserVersion = $browserDocument.getObject('QA.BrowserClass').getProperty('version').getValue())
-      #set($browserIconURL = $doc.getAttachmentURL("${browserName}.png"))
-      #set($discard = $row.put('browser', "&lt;img src=""$browserIconURL""/&gt; &lt;span&gt;$!browserName $!browserVersion&lt;/span&gt;"))
+      #if ("$!browserName" != '')
+        #set($browserIconURL = $doc.getAttachmentURL("${browserName}.png"))
+        #set($discard = $row.put('browser', "&lt;img src=""$browserIconURL""/&gt; &lt;span&gt;$!browserName $!browserVersion&lt;/span&gt;"))
+      #end
     #else
       #set($discard = $row.put('browser', "$browserDocument"))
     #end
@@ -223,9 +235,21 @@
         #if("$!{servletContainerName}" != '')
             #set($servletContainerIconURL = $doc.getAttachmentURL("${servletContainerName}.png"))
             #set($discard = $row.put('servletContainer', "&lt;img src=""$!servletContainerIconURL""/&gt; &lt;span&gt;$!servletContainerName $!servletContainerVersion&lt;/span&gt;"))
-        #end        
+        #end
     #else
         #set($discard = $row.put('servletContainer', "$servletContainerDocument"))
+    #end
+    ##
+    #set($javaDocument = $xwiki.getDocument($item.get(10)))
+    #if(!$javaDocument.isNew())
+        #set($javaName = $javaDocument.getObject('QA.JavaClass').getProperty('name').getValue())
+        #set($javaVersion = $javaDocument.getObject('QA.JavaClass').getProperty('version').getValue())
+        #if("$!{javaName}" != '')
+            #set($javaIconURL = $doc.getAttachmentURL("${javaName}.png"))
+            #set($discard = $row.put('java', "&lt;img src=""$!javaIconURL""/&gt; &lt;span&gt;$!javaName $!javaVersion&lt;/span&gt;"))
+        #end
+    #else
+        #set($discard = $row.put('java', "$javaDocument"))
     #end
     ##
     #set($discard = $row.put('user', "$xwiki.getUserName($item.get(5), true)"))
@@ -255,6 +279,46 @@
   Custom LiveTableResults page to compute the results for LiveTables which are used on TestSheet and ProductSheet pages
 #end
 {{/velocity}}</content>
+  <attachment>
+    <filename>AdoptOpenJDK.png</filename>
+    <mimetype>image/png</mimetype>
+    <charset>UTF-8</charset>
+    <author>xwiki:XWiki.Admin</author>
+    <version>1.1</version>
+    <comment/>
+    <content>iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAIAAABvFaqvAAAACXBIWXMAAA7EAAAOxAGVKw4bAAABs0lEQVQ4y+1TvW/TQBzNHweCBUQkUlCGSp0ZqbohxJKhYunC2K6s3aiQAlVSwHHzWUhdmcQJceIQO/5QYvvO9p15F6f5C7KR0zvr+Z3v+fe7p8ulWxq5ndH/bcRJmlAwnqYJExKPQojgjK9FGiUACF/tSZJks3+xWGyMYpZESz+8/T0Yz+zpX5Oz2PfsbFtmFJIIyHwxoigKgsBxHMYY50IDyWEulkG58v3Bk+cPnxbye8XhHx1rpmXbjgfMzPl4MgWsuYMvPc+zbbvX66mqqmlaHMf3RjwFVXXz9ZvS6cfzd8cnhuV+uvjc7vwEWu0bIOMZZFnu9/ud1ahWq5ZlEUJEa6gMRk1FO3h1+P7D2dHbEozKXy4bzXZNrv+Q5Hqj9aurANf1ZqX6TZIkGHW7XUVRarWa67prI8wgpF+vpEfPXjzOvywU943pDCJ6GQxHfW0IMrddYKRPlDvVNE20puu6YRjgIhzOwzDMMRqkIp+UMFHa6jjZ0p0jJkJjIEIYbJ0dfollSimq8H1/kx0UEX9CfLFGYz8QRaYxgZhFlgFewPqVc6SWHTCeaG1313ZG2zP6BwhEhcCg1Lm9AAAAAElFTkSuQmCC</content>
+    <filesize>513</filesize>
+  </attachment>
+  <attachment>
+    <filename>AmazonJDK.png</filename>
+    <mimetype>image/png</mimetype>
+    <charset>UTF-8</charset>
+    <author>xwiki:XWiki.Admin</author>
+    <version>1.1</version>
+    <comment/>
+    <content>iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAMAAADXqc3KAAADAFBMVEX////+/v79/f36+vv8/Pz6+/v8/f37+/v7/PzQ0tZrcn1WXWltdH7y8vOssLa0t73Jy8+PlJv3+PiLkJjx8vOipq1UXGhhaXTIy8++wcawtLnc3uBcZG95f4mjp65DTFl3fYcSHS3Gyc1ASVe2ur82QE7d3+G/wsfJzNDb3N/Aw8iTmKDu7/A6RFLs7e5yeYNWXmqUmaCCiJDX2dwpM0Lz8/SMkpo/SFWBiJFdZXBTW2hVXWmZnqV8g4ykqa+IjpZqcXy1ub4wOUikqK8tNkW7vsOVmqE/SFaXnKMtN0WWm6Lp6utCS1hRWWX19vagpas5Q1H+/v1/hY4+R1VlbXhLU2De4OIZJDS8wMQ6Q1FvdoCztrxOVmNqb3hDS1Wjpan+/fz+///Iyszx8fLm5+n6+vrq6+3y8/T7+/yyu8ja4u7+8eH+/v/9/Pr///7//vz/8s7/0pL4vXH95cb+/Pr95MX5vW/627L8/v/9/Pv+/fv+/Pv9///54cL60p/5vGz9+vT97dj5tl74qD/6xoH85sn++fP++/j96tH7zI75s1r82q/7z5b827D9/Pn84Lv5sFD3mBv3mh/4pTn5sVP6uGP6uWP5slb4pz74nSf3nSf5tl385MT7zpT//v3+/vz98+b82Kn6wXb5slX5rEj5rEn5tFn6xHz83LP+9u3+/foAAAAAAAAAAAAAZAA5AAAAAwCU80AAAAgDAAAAAAAAAABF2ACHCJoImkeaR4jzMAgACJQA6wBV8yDy3AD2AFV3pPamCEkAAHcAAAAAAAAAAAAAAAAAAAAAAAAOlg14kmiAdpsAVfObeO0At3YAAAAAAAAAAAB5YsBgdpsAAAAAAAUAgACAAADAEAAAAAAAAACIAAAAAAUAAAAAAwB2AAAAeACaR4jzqAgAAFUAAAAAAABHiAAACJoAAACpCyQAAHcAAAAAAAAAAAAAAAAYAAAAAAAAAADzIABAAFUAAAAAAADzcAAAAFUAAAAAAH4ADAACAAAAAACgAQE0ngjEAfsY2jMnAAAAAWJLR0QAiAUdSAAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAUtJREFUKM+9UNVSxAAM3JTC4c7h7u7u7lLcaXHXYsXd3d31K+lxzHA/AHnJZDfZJAv8RxAYLVabWBY6CpCCFLoKRga/GY0mjcyQnr6BoZGxCZmawdzC0kppbUOsTLCwtbN3cHRyhouruZu7h6eXtw8Y9Zyvn78yIDAoOMQ0NCw8wilSLcVSVHRMbBziExKTklNS4aFMS/+WImRkIisbObl5+QWFRkVAcYlKiliutEy/vKKosqoaNbWoq29obOJZWYwENPughaHWNmrvoE69rm4IMs6hpxfoQ7/6BxrA4NDwCIkQaXRsfAICuElJmuIFTM/Mzs3RvDwiLCwuLa+sqn9eW9/Y3Nrewa58FC8Ie/sHh0fHJ6dn5xeXV9fSzRqpluP2Drh/eHx6fnl9e/8AxB+zZPaO+zWS51T4zylE3Kco8bwkSpxckKbjfxhfumVGjYZ+rRUAAAAASUVORK5CYII=</content>
+    <filesize>1202</filesize>
+  </attachment>
+  <attachment>
+    <filename>OracleJDK.png</filename>
+    <mimetype>image/png</mimetype>
+    <charset>UTF-8</charset>
+    <author>xwiki:XWiki.Admin</author>
+    <version>1.1</version>
+    <comment/>
+    <content>iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAACXBIWXMAAA7EAAAOxAGVKw4bAAACcklEQVRIx7VWy27aQBT1Nv297voFlbpDqOqmEhs2VdeV+gnpQ2kbKW0ANYRHIggp74Y3BIJxeT+MwYPHp3NHUVahGJKOZFkez5xzzznXGisej0fxer1P/H6/ez6fawBs7D5swggEAm7CJGwJLiZeGoYxsMXAAwdhEBZhCuw9hSqnia1AuCWA+D/XEKbP53MpJGnbyvm4Dj5TNyrRdV1VtvWcarGqR+D9K0fLlW3Bef83WOwNbKY72qM4B+ewbiJgJ27wbgZ8UJQ2bXJXcRqqVToA++mC1QpjlXoPS43BttjjKCBbzMNnouoSWPi1UBKF075wREDVstNXsI0+zC9PwbVLx7k5s0gEukq+E563wSIemL7nYs54HAKyYmVxcF0TSuLgoxpM/wvYy4l8tzAZlmy11rK1BJxz5BsaTlJltLoj8SxadLUAm3UxV9MY64YE14ZTHJ7n0R3PtiOgqkOZKr6d5xDO1hDN1xHJ1eU9UWqh3O5JAqr8IJpFtq7uZlGmpiJWuEZTqFAHE1z/GSHX6KCq9mURdW0A/2UJhsl2IyDQHxcFfAqlsX+awudwBseJAootYdXSRG+sS6KdQ54aS+wHkwK0KC2jar+e5dDuTxx9C/cSUFfk6h00hHxjyVC+6eEofoUPQgGBxwtNGTIR0NrhdL4dQUMb4u3HoAwvJAJOFFtIVdtIiytZactnIqHrotiUOekLcy2BfV/vU4f0J7rcHExXhDVFmcV3oYTugV8l0cIVnOUbqHUG63KwNx44/JaMsiBbRjMDk/lCBkyg67beHTi7HJlOxt2R+d8P/dvflj2hxCUkdR7620IYhEWYhP0XgyKSTyZvPdYAAAAASUVORK5CYII=</content>
+    <filesize>704</filesize>
+  </attachment>
+  <attachment>
+    <filename>OpenJDK.png</filename>
+    <mimetype>image/png</mimetype>
+    <charset>UTF-8</charset>
+    <author>xwiki:XWiki.Admin</author>
+    <version>1.1</version>
+    <comment/>
+    <content>iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDI0LTA5LTIzVDEzOjQzOjAyKzAwOjAwnz4YCgAAACV0RVh0ZGF0ZTptb2RpZnkAMjAyNC0wOS0yM1QxMzo0MzowMiswMDowMO5joLYAAAAodEVYdGRhdGU6dGltZXN0YW1wADIwMjQtMDktMjNUMTM6NDM6MDIrMDA6MDC5doFpAAAD4ElEQVRIx51WS08bVxS2IrHqokjwE1qx6qbKjmUr/kEX3bDoAtFFFxGNKqVyWgUZQVOKkkhYdnnI3UQGnGYAG/CDYGIqEtcIbEpSaIJRsJuIGT/GnvHYM+Ov917POBhMUnOko+u559zznbdsAVBtxpSanZVKpf6taVqDrBlbjB9NqfYO0HWdsfktCMI5HfM8SxcCNHuoqir8fj96e3thtVoxPj7O5PT+UgCm17u7u4jH4+y+v78fnZ2daGtrg8PhYHckbf8f4LQifUjJ5/Oho6MDB/v7iEajsFgsjAcHB5k+1aPOtBSBmRJqIBKJMIMfd3VhZGQEPT09aG9vx+bmJpOTYrcegekZpZXlZQbw4ZUr6Pnsc3bn8XiY4XcV+L0A5XKZnY6JCXzx6SfQr30D2wft+M5mw9zMDGRZrtfpUkU2Ixi5exc3rl5F/KMurF27DuvwMO6MjTGZ6UTLEZie0Z7v6+vDi8NDhP0BiMRgNpOBy+Vieu/K/4URmIWjNDk5iYGBgbdCA3h6eho8z9edaTkCs4MmSP4pCAWUJQmKojCDwWCQteyluuh0/oeGhuB2u889TCQSCAQCDc60BEBZIh53d3cjnU7jkNTAbrfD6XSy1BwfH4PjuPevCmMTEgWSW02tGzcfUSM0RZQpSDKZxNTUFLxeLxYJa5pOOqnSsFq0U4vRYqzbM0Um29MAS6WOyaAtNcj/JRE57OMQ8/m3tW8SAX1vqeoaEymv/0Z+YwqqnLtwdZtLXhAlvBKKSAt5/B6JI/EyxXS2Dl5BKinY3DuEKJWYNkmRXlULJxAWf0Q+NocMOSviG0j7YWiVEsriCYrJGPNQOtqC+noPqzv/4JfZEH4LRHHTtYRvHQ8Rjh9g2B2E07uB0dlVlCsqVNJdLEWll39ADN9jXmQXbiIbuA3Bewv5xw5kCZ9w36MYc4NfskFZHcba4zU4l/9kAE+eJxFJvMDtmVX8RPhLmwsyaWVzPhiAkowitzLEws9wNyBGfkVFSCKzYAXvGUDhWQjFHQ6F+DzwjEPINwunfxvTK0/waHsf7rUt2BciGHsQxlc/38fy073aule1Wg00RQJPPOcXbqGw64O4MQGBANE0ZYOjELc5yEcx5LfmUH0+j5B/HvcWn+LhRhxf35nFDy4fUnwOo3OPsL5zgOsODny+SCIwasB2ilKAkvqLIedCo5CJcTZEch7l9B60soQKcaSqlvBgPQbP+g4UkuejNxniqVpLb0EiLaohV5RJmmpL8FybVkne1CJv/LXQ61N4+q9CQVbqu+psmzbYYm1aI2PA9IaxNiaQ3bOvqsFNpr4ZU/oP+PZL6zUwHCcAAAAASUVORK5CYII=</content>
+    <filesize>1220</filesize>
+  </attachment>
   <attachment>
     <filename>Apache Derby.png</filename>
     <mimetype>image/png</mimetype>

--- a/src/main/resources/QA/Management.xml
+++ b/src/main/resources/QA/Management.xml
@@ -145,6 +145,26 @@
   (%class="buttonwrapper"%)[[$services.localization.render('qaapp.Management.AddServletContainer.button')&gt;&gt;QA.AddServletContainer]]
   #livetable("servlets" $collist $colprops $options)
 #end
+= Existing Java Versions =
+#set($hql = ", BaseObject as obj where doc.fullName = obj.name and obj.className = 'QA.JavaClass'")
+#set($results = $xwiki.searchDocuments($hql, 0, 0))
+#if(!$results.isEmpty())
+
+  #set($collist = ["doc.name", "doc.space", "doc.date", "doc.author", "_actions"])
+  #set($colprops = {
+                   "doc.name" : { "type" : "text" ,"link" : "true", "size" : 30, "sortable":true, "filterable":true},
+                   "_ratings" : { "sortable":false},
+                   "doc.date" : { "type" : "date" },
+                   "doc.author" : { "type" : "text", "link" : "author"},
+                   "_actions" : { 'actions' : ['delete'] }
+                 })
+  #set($options = { "className":"QA.JavaClass",
+                  "tagCloud" : false,
+                  "translationPrefix" : "xe.index.",
+                  "rowCount": 10 })
+  (%class="buttonwrapper"%)[[$services.localization.render('qaapp.Management.AddJava.button')&gt;&gt;QA.AddJava]]
+  #livetable("javaVersions" $collist $colprops $options)
+#end
 
 = Fix application property =
   (%class="buttonwrapper"%)[[Set application value to "None"&gt;&gt;QA.FixAppValue]]

--- a/src/main/resources/QA/TestSheet.xml
+++ b/src/main/resources/QA/TestSheet.xml
@@ -105,13 +105,14 @@
     == Results ==
     #set($discard = $xwiki.ssx.use("QA.WebHome"))
     #set($discard = $xwiki.jsx.use("QA.WebHome" ,{'minify':false,'defer':false}))
-    #set($columns = ['product', 'application', 'browser', 'database', 'servletContainer', 'user', 'date', 'passed', 'jira'])
+    #set($columns = ['product', 'application', 'browser', 'database', 'servletContainer', 'java', 'user', 'date', 'passed', 'jira'])
     #set($columnsProperties = {
       'product'      :{'type': 'suggest', 'html' :true, 'filterable': true, 'sortable': true},
       'application'  :{'type': 'suggest', 'html' :true, 'filterable': true, 'sortable': true},
       'browser'      :{'type': 'suggest', 'html': true, 'filterable': true, 'sortable': true},
       'database'     :{'type': 'suggest', 'html': true, 'filterable': true, 'sortable': true},
       'servletContainer' :{'type': 'suggest', 'html': true, 'filterable': true, 'sortable': true},
+      'java'  :{'type': 'suggest', 'html' :true, 'filterable': true, 'sortable': true},
       'user'         :{'type': 'suggest', 'html': true, 'filterable': true, 'sortable': true},
       'date'         :{'type': 'date', 'html': true, 'filterable': true, 'sortable': true},
       'passed'       :{'type': 'boolean', 'html': true, 'filterable': true, 'sortable': true},

--- a/src/main/resources/QA/TestSpaceWebHomeTemplate.xml
+++ b/src/main/resources/QA/TestSpaceWebHomeTemplate.xml
@@ -40,7 +40,7 @@
 (%class="buttonwrapper"%)[[Add new Test&gt;&gt;QA.AddTest||queryString="spaceName=${doc.space}"]] [[Home&gt;&gt;QA.WebHome]]
 #set($discard = $xwiki.ssx.use("QA.WebHome"))
 #set($discard = $xwiki.jsx.use("QA.WebHome" ,{'minify':false,'defer':false}))
-#set($columns = ['doc.title', 'wikiType', 'userType', 'product', 'browsers', 'databases', 'servletContainers', 'automated'])
+#set($columns = ['doc.title', 'wikiType', 'userType', 'product', 'browsers', 'databases', 'servletContainers', 'javas', 'automated'])
 #set($columnsProperties = {
   'doc.title'      :{'type': 'text', 'link': 'view', 'size': 10, 'filterable': true, 'sortable': true},
   'wikiType'      :{'type': 'list', 'class': 'QA.TestClass'},
@@ -49,6 +49,7 @@
   'browsers'      :{'type': 'text', 'html': true, 'filterable': false, 'sortable': false},
   'databases'     :{'type': 'text', 'html': true, 'filterable': false, 'sortable': false},
   'servletContainers'      :{'type': 'text', 'html': true, 'filterable': false, 'sortable': false},
+  'javas'      :{'type': 'text', 'html': true, 'filterable': false, 'sortable': false},
   'automated'     :{'type': 'list', 'class': 'QA.TestClass'},
   '_actions'      :{'actions': [
     {

--- a/src/main/resources/QA/Translations.xml
+++ b/src/main/resources/QA/Translations.xml
@@ -41,10 +41,11 @@ qaapp.WebHome.LiveTable.doc.creationDate=Creation Date
 qaapp.WebHome.LiveTable.doc.date=Update Date
 qaapp.WebHome.LiveTable.doc.title=Test
 qaapp.WebHome.LiveTable.doc.space=Category
-qaapp.WebHome.LiveTable.product=Latest product version tested
+qaapp.WebHome.LiveTable.product=Latest version tested
 qaapp.WebHome.LiveTable.browsers=Browsers
 qaapp.WebHome.LiveTable.databases=Databases
-qaapp.WebHome.LiveTable.servletContainers=Servlet Containers
+qaapp.WebHome.LiveTable.servletContainers=Containers
+qaapp.WebHome.LiveTable.javas=Java
 qaapp.WebHome.LiveTable.automated=Automated
 qaapp.WebHome.LiveTable._actions=Action
 qaapp.WebHome.LiveTable.no.tests.execution.found=No test executions found
@@ -62,7 +63,8 @@ qaapp.Custom.LiveTable.product=Product
 qaapp.Custom.LiveTable.browser=Browsers
 qaapp.Custom.LiveTable.browsers=Browsers
 qaapp.Custom.LiveTable.database=Databases
-qaapp.Custom.LiveTable.servletContainer=Servlet Containers
+qaapp.Custom.LiveTable.servletContainer=Containers
+qaapp.Custom.LiveTable.java=Java
 qaapp.Custom.LiveTable.user=Tested By
 qaapp.Custom.LiveTable.date=Tested On
 qaapp.Custom.LiveTable.passed=Result
@@ -82,6 +84,7 @@ qaapp.Management.AddProduct.button=Add new Product Version
 qaapp.Management.AddBrowser.button=Add new Browser
 qaapp.Management.AddDatabase.button=Add new Database
 qaapp.Management.AddServletContainer.button=Add new Servlet Container
+qaapp.Management.AddJava.button=Add new Java Version
 qaapp.Management.AddApp.button=Add new App Version
 
 # Translations for the Add Test form
@@ -108,6 +111,13 @@ qaapp.AddDatabase.databaseVersion.label=Database Version
 qaapp.AddServletContainer.servletName=Add a new servlet container
 qaapp.AddServletContainer.servletName.label=Servlet Container Name
 qaapp.AddServletContainer.servletVersion.label=Servlet Container Version
+
+# Translation in the Add Java container
+qaapp.AddJava.java.label=Java Version
+qaapp.AddJava.javaVersion=Add a new java version
+qaapp.AddJava.javaVersion.label=Java Version
+qaapp.AddJava.javaName=Add a new JDK vendor
+qaapp.AddJava.javaName.label=JDK Vendor Name
 
 # Translations in the Add App form
 qaapp.AddApp.button=Add a new app

--- a/src/main/resources/QA/WebHome.xml
+++ b/src/main/resources/QA/WebHome.xml
@@ -39,7 +39,7 @@
   <content>{{velocity}}
 #set($discard = $xwiki.ssx.use("QA.WebHome"))
 #set($discard = $xwiki.jsx.use("QA.WebHome" ,{'minify':false,'defer':false}))
-#set($columns = ['deprecated','doc.title', 'doc.space', 'wikiType', 'userType', 'product', 'browsers', 'databases', 'servletContainers', 'automated'])
+#set($columns = ['deprecated','doc.title', 'doc.space', 'wikiType', 'userType', 'product', 'browsers', 'databases', 'servletContainers', 'javas', 'automated'])
 #set($columnsProperties = {
   'doc.title'      :{'type': 'text', 'link': 'view', 'size': 10, 'filterable': true, 'sortable': true},
   'doc.space'     :{'type': 'text', 'link': 'space', 'size': 10, 'filterable': true, 'sortable': true},
@@ -49,6 +49,7 @@
   'browsers'      :{'type': 'text', 'html': true, 'filterable': false, 'sortable': false},
   'databases'     :{'type': 'text', 'html': true, 'filterable': false, 'sortable': false},
   'servletContainers'     :{'type': 'text', 'html': true, 'filterable': false, 'sortable': false},
+  'javas'     :{'type': 'text', 'html': true, 'filterable': false, 'sortable': false},
   'automated'     :{'type': 'list', 'class': 'QA.TestClass'},
   'deprecated'     :{'type': 'list', 'class': 'QA.TestClass'}
 })
@@ -367,6 +368,14 @@
 }
 
 .databaseVersions{
+  font-size:10px;
+}
+
+.javaVersions{
+  font-size:10px;
+}
+
+.servletContainerVersions{
   font-size:10px;
 }</code>
     </property>


### PR DESCRIPTION
* Added Java version column in Space, WebHome and Hall of Fame livetables
* Modified some translations to better fit the tables in the page (with the new Java column)
* Modified text size for displaying item versions (java and servlet container) to be consistent with the other columns
* Added icons for some JDK versions
* Fixed a broken Velocity output when no Browser is selected in the Full Details LiveTable