### PR TITLE
TESTREPORT-43: Cannot insert text by keyboard in the editable fields when adding or editing a test

### DIFF
--- a/src/main/resources/QA/ExecutionAddSheet.xml
+++ b/src/main/resources/QA/ExecutionAddSheet.xml
@@ -306,15 +306,10 @@
     </property>
     <property>
       <code>require(['jquery'], function($) {
-  let submitButton = $('input.button[name="addObject"]');
-  $(document)
-      .on('keypress', function (event) {
-        if (event.which === 117) {
-          submitButton.click();
-        }
-        event.stopImmediatePropagation();
-        event.preventDefault();
-      });
+  shortcut.add("Alt+Shift+q", function() {
+    let submitButton = $('input.button[name="addObject"]');
+    submitButton.click();
+  });
 });</code>
     </property>
     <property>

--- a/src/main/resources/QA/TestSheet.xml
+++ b/src/main/resources/QA/TestSheet.xml
@@ -38,7 +38,6 @@
   <hidden>true</hidden>
   <content>{{velocity}}
 #set($discard=$xwiki.ssx.use('QA.TestSheet'))
-#set($discard=$xwiki.jsx.use('QA.TestSheet'))
 #if(($context.action=="inline")||($context.action=="edit"))
   #set ($useWysiwygEditor = $xwiki.getUserPreference('editor') == 'Wysiwyg')
   #set($type="edit")
@@ -80,6 +79,7 @@
 {{velocity}}
 #if ($context.action=="view")
   #if($doc.getObject('QA.TestClass'))
+    #set($discard=$xwiki.jsx.use('QA.TestSheet'))
     (%class="buttonwrapper"%)[[Home&gt;&gt;QA.WebHome]] (%class="buttonwrapper"%)[[$doc.space Home&gt;&gt;${doc.space}.WebHome]] (%class="buttonwrapper"%)[[Run Test&gt;&gt;$doc||queryString="sheet=QA.ExecutionAddSheet"]]
      == Steps to reproduce ==
 
@@ -229,15 +229,10 @@
     </property>
     <property>
       <code>require(['jquery'], function($) {
-  let submitButton = $('span.wikilink&gt;a[href$="sheet=QA.ExecutionAddSheet"]')[0];
-  $(document)
-      .on('keypress', function (event) {
-        if (event.which === 117) {
-          submitButton.click();
-        }
-        event.stopImmediatePropagation();
-        event.preventDefault();
-      });
+  shortcut.add("Alt+Shift+q", function() {
+    let submitButton = $('span.wikilink&gt;a[href$="sheet=QA.ExecutionAddSheet"]')[0];
+    submitButton.click();
+  });
 });</code>
     </property>
     <property>


### PR DESCRIPTION
* Fixed js include so it is only active on the view page
* Fixed js event listener to not intercept all keystrokes
* Modified "Run Test" shortcut to "Alt+Shift+q" to not interfere with writing
* Use shortcut.js instead of jquery events