### PR TITLE
TESTREPORT-29: Display new Automation Status in tests and add a column for it in LiveTables

### DIFF
--- a/src/main/resources/QA/AddMissingAutomatedTestStatusClassXObjects.xml
+++ b/src/main/resources/QA/AddMissingAutomatedTestStatusClassXObjects.xml
@@ -1,0 +1,74 @@
+<?xml version="1.1" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<xwikidoc version="1.4" reference="QA.AddMissingAutomatedTestStatusClassXObjects" locale="">
+  <web>QA</web>
+  <name>AddMissingAutomatedTestStatusClassXObjects</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <parent>QA.Management</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <version>1.1</version>
+  <title>Add Missing AutomatedTestStatusClass XObjects</title>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>true</hidden>
+  <content>{{html}}
+&lt;form&gt;
+  &lt;input type="hidden" id="fixAction" name="fixAction" value="addMissing"&gt;
+  &lt;button class="btn btn-primary"&gt;
+    Add missing XObjects
+  &lt;/button&gt;
+&lt;/form&gt;
+{{/html}}
+
+The following documents have issues related to the QA.AutomatedTestStatusClass XObject:
+
+{{velocity wiki="true"}}
+|=Document|=QA.AutomatedTestStatusClass XObject Status
+#set ($statement = 'from doc.object(QA.TestClass) as user')
+#foreach ($docName in $services.query.xwql($statement).execute())
+  #set ($document = $xwiki.getDocument($docName))
+  #set ($objs = $document.getObjects('QA.AutomatedTestStatusClass'))
+  #if ($objs.isEmpty())
+    #set ($status = 'No XObject')
+    #if ($request.fixAction == 'addMissing')
+      #set ($discard = $document.createNewObject('QA.AutomatedTestStatusClass'))
+      #set ($discard = $document.save('Added missing QA.AutomatedTestStatusClass XObject'))
+      #set ($status = 'No XObject (Fixed)')
+    #end
+  #elseif ($objs.size() &gt; 1)
+    #set ($status = 'Multiple XObjects')
+  #else
+    #set ($status = 'Ok')
+  #end
+  #if ($status != 'Ok')
+    | [[$services.rendering.escape($docName, 'xwiki/2.1')]] | $status
+  #end
+#end
+{{/velocity}}
+</content>
+</xwikidoc>

--- a/src/main/resources/QA/AutomatedTestStatusClass.xml
+++ b/src/main/resources/QA/AutomatedTestStatusClass.xml
@@ -87,7 +87,7 @@
       <freeText/>
       <hint/>
       <largeStorage>0</largeStorage>
-      <multiSelect>1</multiSelect>
+      <multiSelect>0</multiSelect>
       <name>status</name>
       <number>1</number>
       <picker>1</picker>

--- a/src/main/resources/QA/ExecutionAddSheet.xml
+++ b/src/main/resources/QA/ExecutionAddSheet.xml
@@ -86,14 +86,18 @@
     ; &lt;label&gt;Expected Results&lt;/label&gt;
     #if($doc.name!='ExecutionAddSheet')
     : $doc.display('expectedResult', $doc.getObject('QA.TestClass'))
-    #end
-    #if($doc.name!='ExecutionAddSheet')
     ; &lt;label&gt;{{translation key=qaapp.WebHome.LiveTable.userType/}}&lt;/label&gt;
     : $doc.display('userType', $doc.getObject('QA.TestClass'))
-    #end	
-    #if($doc.name!='ExecutionAddSheet')
+    #set ($automatedProperty = $doc.getObject('QA.TestClass').getProperty('automated'))
+    #if ($automatedProperty.value == "automated")
+      #set ($automatedIcon = 'check')
+    #elseif ($automatedProperty.value == "needsTest")
+      #set ($automatedIcon = 'warning')
+    #elseif ($automatedProperty.value == "notAutomatable")
+      #set ($automatedIcon = 'remove')
+    #end
     ; &lt;label&gt;Automated&lt;/label&gt;
-    : $doc.display('automated', $doc.getObject('QA.TestClass')) #if($doc.getObject('QA.TestClass').getProperty('automated').value == "yes") [[image:icon:accept]] #else [[image:icon:cancel]] #end
+    : $services.icon.renderHTML($automatedIcon) $doc.display('automated', $doc.getObject('QA.TestClass'))
     #end
     &lt;div class="hidden"&gt;
       &lt;input type="hidden" name="form_token" value="$!{services.csrf.getToken()}"/&gt;

--- a/src/main/resources/QA/ExecutionAddSheet.xml
+++ b/src/main/resources/QA/ExecutionAddSheet.xml
@@ -85,19 +85,21 @@
     #end
     ; &lt;label&gt;Expected Results&lt;/label&gt;
     #if($doc.name!='ExecutionAddSheet')
-    : $doc.display('expectedResult', $doc.getObject('QA.TestClass'))
-    ; &lt;label&gt;{{translation key=qaapp.WebHome.LiveTable.userType/}}&lt;/label&gt;
-    : $doc.display('userType', $doc.getObject('QA.TestClass'))
-    #set ($automatedProperty = $doc.getObject('QA.TestClass').getProperty('automated'))
-    #if ($automatedProperty.value == "automated")
-      #set ($automatedIcon = 'check')
-    #elseif ($automatedProperty.value == "needsTest")
-      #set ($automatedIcon = 'warning')
-    #elseif ($automatedProperty.value == "notAutomatable")
-      #set ($automatedIcon = 'remove')
-    #end
-    ; &lt;label&gt;Automated&lt;/label&gt;
-    : $services.icon.renderHTML($automatedIcon) $doc.display('automated', $doc.getObject('QA.TestClass'))
+      : $doc.display('expectedResult', $doc.getObject('QA.TestClass'))
+      ; &lt;label&gt;{{translation key=qaapp.WebHome.LiveTable.userType/}}&lt;/label&gt;
+      : $doc.display('userType', $doc.getObject('QA.TestClass'))
+      #if ($doc.getObject('QA.AutomatedTestStatusClass'))
+        #set ($automatedProperty = $doc.getObject('QA.AutomatedTestStatusClass').getProperty('status'))
+        #if ($automatedProperty.value == "Automated")
+          #set ($automatedIcon = 'check')
+        #elseif ($automatedProperty.value == "Needs Automated Test")
+          #set ($automatedIcon = 'warning')
+        #elseif ($automatedProperty.value == "Not Automatable")
+          #set ($automatedIcon = 'remove')
+        #end
+        ; &lt;label&gt;Automated&lt;/label&gt;
+        : $services.icon.renderHTML($automatedIcon) $doc.display('status', $doc.getObject('QA.AutomatedTestStatusClass'))
+      #end
     #end
     &lt;div class="hidden"&gt;
       &lt;input type="hidden" name="form_token" value="$!{services.csrf.getToken()}"/&gt;

--- a/src/main/resources/QA/ExecutionTemplate.xml
+++ b/src/main/resources/QA/ExecutionTemplate.xml
@@ -359,6 +359,9 @@
       <date>2012-11-30 11:47:03.0</date>
     </property>
     <property>
+      <distribution/>
+    </property>
+    <property>
       <java/>
     </property>
     <property>

--- a/src/main/resources/QA/LiveTableResults.xml
+++ b/src/main/resources/QA/LiveTableResults.xml
@@ -192,11 +192,6 @@
     #set($discard = $row.put("javas", ''))
     #set($discard = $row.put("distributions", ''))
   #end
-  #set ($maybeAutomatedXObject = $xwiki.getDocument("${row.doc_space}.${row.doc_name}"))
-  #set ($maybeAutomatedXObject = $maybeAutomatedXObject.getObject('QA.AutomatedTestStatusClass'))
-  #if ($maybeAutomatedXObject)
-    #set ($discard = $row.put("automated","$maybeAutomatedXObject.status"))
-  #end
   #set($test = "${row.doc_space}.${row.doc_name}")
   #set($discard = $row.put("doc_runTest_url", $xwiki.getURL($row.doc_fullName, 'get', "sheet=QA.ExecutionAddSheet")))
 ##ExtendRow Macro End
@@ -213,7 +208,7 @@
   #end
   ##
   ##
-  #gridresultwithfilter_buildJSON('QA.TestClass' ['doc.title', 'doc.space', 'automated','deprecated', 'userType', 'wikiType'] '' $filterWhere $filterParams $map)
+  #gridresultwithfilter_buildJSON('QA.TestClass' ['doc.title', 'doc.space', 'automated', 'status','deprecated', 'userType', 'wikiType'] '' $filterWhere $filterParams $map)
   #foreach ($row in $map.rows)
     #extendRow($row)
   #end

--- a/src/main/resources/QA/LiveTableResults.xml
+++ b/src/main/resources/QA/LiveTableResults.xml
@@ -192,11 +192,6 @@
     #set($discard = $row.put("javas", ''))
     #set($discard = $row.put("distributions", ''))
   #end
-  #set ($maybeAutomatedXObject = $xwiki.getDocument("${row.doc_space}.${row.doc_name}"))
-  #set ($maybeAutomatedXObject = $maybeAutomatedXObject.getObject('QA.AutomatedTestStatusClass'))
-  #if ($maybeAutomatedXObject)
-    #set ($discard = $row.put("automated","$maybeAutomatedXObject.status"))
-  #end
   #set($test = "${row.doc_space}.${row.doc_name}")
   #set($discard = $row.put("doc_runTest_url", $xwiki.getURL($row.doc_fullName, 'get', "sheet=QA.ExecutionAddSheet")))
 ##ExtendRow Macro End

--- a/src/main/resources/QA/LiveTableResults.xml
+++ b/src/main/resources/QA/LiveTableResults.xml
@@ -192,6 +192,11 @@
     #set($discard = $row.put("javas", ''))
     #set($discard = $row.put("distributions", ''))
   #end
+  #set ($maybeAutomatedXObject = $xwiki.getDocument("${row.doc_space}.${row.doc_name}"))
+  #set ($maybeAutomatedXObject = $maybeAutomatedXObject.getObject('QA.AutomatedTestStatusClass'))
+  #if ($maybeAutomatedXObject)
+    #set ($discard = $row.put("automated","$maybeAutomatedXObject.status"))
+  #end
   #set($test = "${row.doc_space}.${row.doc_name}")
   #set($discard = $row.put("doc_runTest_url", $xwiki.getURL($row.doc_fullName, 'get', "sheet=QA.ExecutionAddSheet")))
 ##ExtendRow Macro End

--- a/src/main/resources/QA/Management.xml
+++ b/src/main/resources/QA/Management.xml
@@ -189,6 +189,8 @@
 = Fix application property =
   (%class="buttonwrapper"%)[[Set application value to "None"&gt;&gt;QA.FixAppValue]]
 
+= Add Missing QA.AutomatedTestStatusClass XObjects =
+  (%class="buttonwrapper"%)[[Add Missing QA.AutomatedTestStatusClass XObjects&gt;&gt;QA.AddMissingAutomatedTestStatusClassXObjects]]
 
 {{/velocity}}</content>
 </xwikidoc>

--- a/src/main/resources/QA/TestClass.xml
+++ b/src/main/resources/QA/TestClass.xml
@@ -63,34 +63,20 @@
       <largeStorage>0</largeStorage>
       <multiSelect>0</multiSelect>
       <name>automated</name>
-      <number>4</number>
-      <picker>0</picker>
-      <prettyName>Automated</prettyName>
+      <number>3</number>
+      <picker>1</picker>
+      <prettyName>Automation Status</prettyName>
       <relationalStorage>0</relationalStorage>
       <separator> </separator>
-      <separators> ,|</separators>
+      <separators>|, </separators>
       <size>1</size>
-      <sort>none</sort>
+      <sort/>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
-      <values>yes=Yes|no=No</values>
+      <values>automated=Automated|notAutomatable=Not Automatable|needsTest=Needs Automated Test</values>
       <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
     </automated>
-    <automatedLinkSourceCode>
-      <customDisplay/>
-      <disabled>0</disabled>
-      <hint/>
-      <name>automatedLinkSourceCode</name>
-      <number>3</number>
-      <picker>0</picker>
-      <prettyName>Automated Link Source Code</prettyName>
-      <size>30</size>
-      <unmodifiable>0</unmodifiable>
-      <validationMessage/>
-      <validationRegExp/>
-      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-    </automatedLinkSourceCode>
     <deprecated>
       <cache>0</cache>
       <customDisplay/>
@@ -102,7 +88,7 @@
       <largeStorage>0</largeStorage>
       <multiSelect>0</multiSelect>
       <name>deprecated</name>
-      <number>5</number>
+      <number>7</number>
       <picker>0</picker>
       <prettyName>Deprecated</prettyName>
       <relationalStorage>0</relationalStorage>
@@ -123,9 +109,10 @@
       <editor>---</editor>
       <hint/>
       <name>expectedResult</name>
-      <number>2</number>
+      <number>1</number>
       <picker>0</picker>
       <prettyName>Expected result</prettyName>
+      <restricted>0</restricted>
       <rows>5</rows>
       <size>40</size>
       <unmodifiable>0</unmodifiable>
@@ -133,6 +120,56 @@
       <validationRegExp/>
       <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
     </expectedResult>
+    <jira>
+      <customDisplay/>
+      <disabled>0</disabled>
+      <hint/>
+      <name>jira</name>
+      <number>4</number>
+      <picker>1</picker>
+      <prettyName>JIRA link for automating the test</prettyName>
+      <size>30</size>
+      <unmodifiable>0</unmodifiable>
+      <validationMessage/>
+      <validationRegExp/>
+      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+    </jira>
+    <notes>
+      <contenttype>---</contenttype>
+      <customDisplay/>
+      <disabled>0</disabled>
+      <editor>---</editor>
+      <hint/>
+      <name>notes</name>
+      <number>6</number>
+      <picker>1</picker>
+      <prettyName>Notes</prettyName>
+      <restricted>0</restricted>
+      <rows>5</rows>
+      <size>40</size>
+      <unmodifiable>0</unmodifiable>
+      <validationMessage/>
+      <validationRegExp/>
+      <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+    </notes>
+    <tests>
+      <contenttype>---</contenttype>
+      <customDisplay/>
+      <disabled>0</disabled>
+      <editor>---</editor>
+      <hint/>
+      <name>tests</name>
+      <number>5</number>
+      <picker>1</picker>
+      <prettyName>List of automated GitHub test links</prettyName>
+      <restricted>0</restricted>
+      <rows>5</rows>
+      <size>40</size>
+      <unmodifiable>0</unmodifiable>
+      <validationMessage/>
+      <validationRegExp/>
+      <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+    </tests>
     <userType>
       <cache>0</cache>
       <customDisplay/>
@@ -144,7 +181,7 @@
       <largeStorage>0</largeStorage>
       <multiSelect>0</multiSelect>
       <name>userType</name>
-      <number>4</number>
+      <number>1</number>
       <picker>0</picker>
       <prettyName>User Type</prettyName>
       <relationalStorage>0</relationalStorage>
@@ -161,11 +198,15 @@
     <wikiType>
       <cache>0</cache>
       <customDisplay/>
+      <defaultValue/>
       <disabled>0</disabled>
       <displayType>select</displayType>
+      <freeText/>
+      <hint/>
+      <largeStorage>0</largeStorage>
       <multiSelect>0</multiSelect>
       <name>wikiType</name>
-      <number>5</number>
+      <number>2</number>
       <picker>0</picker>
       <prettyName>Wiki Type</prettyName>
       <relationalStorage>0</relationalStorage>

--- a/src/main/resources/QA/TestClass.xml
+++ b/src/main/resources/QA/TestClass.xml
@@ -63,20 +63,34 @@
       <largeStorage>0</largeStorage>
       <multiSelect>0</multiSelect>
       <name>automated</name>
-      <number>3</number>
-      <picker>1</picker>
-      <prettyName>Automation Status</prettyName>
+      <number>4</number>
+      <picker>0</picker>
+      <prettyName>Automated</prettyName>
       <relationalStorage>0</relationalStorage>
       <separator> </separator>
-      <separators>|, </separators>
+      <separators> ,|</separators>
       <size>1</size>
-      <sort/>
+      <sort>none</sort>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
-      <values>automated=Automated|notAutomatable=Not Automatable|needsTest=Needs Automated Test</values>
+      <values>yes=Yes|no=No</values>
       <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
     </automated>
+    <automatedLinkSourceCode>
+      <customDisplay/>
+      <disabled>0</disabled>
+      <hint/>
+      <name>automatedLinkSourceCode</name>
+      <number>3</number>
+      <picker>0</picker>
+      <prettyName>Automated Link Source Code</prettyName>
+      <size>30</size>
+      <unmodifiable>0</unmodifiable>
+      <validationMessage/>
+      <validationRegExp/>
+      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+    </automatedLinkSourceCode>
     <deprecated>
       <cache>0</cache>
       <customDisplay/>
@@ -88,7 +102,7 @@
       <largeStorage>0</largeStorage>
       <multiSelect>0</multiSelect>
       <name>deprecated</name>
-      <number>7</number>
+      <number>5</number>
       <picker>0</picker>
       <prettyName>Deprecated</prettyName>
       <relationalStorage>0</relationalStorage>
@@ -109,10 +123,9 @@
       <editor>---</editor>
       <hint/>
       <name>expectedResult</name>
-      <number>1</number>
+      <number>2</number>
       <picker>0</picker>
       <prettyName>Expected result</prettyName>
-      <restricted>0</restricted>
       <rows>5</rows>
       <size>40</size>
       <unmodifiable>0</unmodifiable>
@@ -120,56 +133,6 @@
       <validationRegExp/>
       <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
     </expectedResult>
-    <jira>
-      <customDisplay/>
-      <disabled>0</disabled>
-      <hint/>
-      <name>jira</name>
-      <number>4</number>
-      <picker>1</picker>
-      <prettyName>JIRA link for automating the test</prettyName>
-      <size>30</size>
-      <unmodifiable>0</unmodifiable>
-      <validationMessage/>
-      <validationRegExp/>
-      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-    </jira>
-    <notes>
-      <contenttype>---</contenttype>
-      <customDisplay/>
-      <disabled>0</disabled>
-      <editor>---</editor>
-      <hint/>
-      <name>notes</name>
-      <number>6</number>
-      <picker>1</picker>
-      <prettyName>Notes</prettyName>
-      <restricted>0</restricted>
-      <rows>5</rows>
-      <size>40</size>
-      <unmodifiable>0</unmodifiable>
-      <validationMessage/>
-      <validationRegExp/>
-      <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
-    </notes>
-    <tests>
-      <contenttype>---</contenttype>
-      <customDisplay/>
-      <disabled>0</disabled>
-      <editor>---</editor>
-      <hint/>
-      <name>tests</name>
-      <number>5</number>
-      <picker>1</picker>
-      <prettyName>List of automated GitHub test links</prettyName>
-      <restricted>0</restricted>
-      <rows>5</rows>
-      <size>40</size>
-      <unmodifiable>0</unmodifiable>
-      <validationMessage/>
-      <validationRegExp/>
-      <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
-    </tests>
     <userType>
       <cache>0</cache>
       <customDisplay/>
@@ -181,7 +144,7 @@
       <largeStorage>0</largeStorage>
       <multiSelect>0</multiSelect>
       <name>userType</name>
-      <number>1</number>
+      <number>4</number>
       <picker>0</picker>
       <prettyName>User Type</prettyName>
       <relationalStorage>0</relationalStorage>
@@ -198,15 +161,11 @@
     <wikiType>
       <cache>0</cache>
       <customDisplay/>
-      <defaultValue/>
       <disabled>0</disabled>
       <displayType>select</displayType>
-      <freeText/>
-      <hint/>
-      <largeStorage>0</largeStorage>
       <multiSelect>0</multiSelect>
       <name>wikiType</name>
-      <number>2</number>
+      <number>5</number>
       <picker>0</picker>
       <prettyName>Wiki Type</prettyName>
       <relationalStorage>0</relationalStorage>

--- a/src/main/resources/QA/TestSheet.xml
+++ b/src/main/resources/QA/TestSheet.xml
@@ -47,20 +47,16 @@
     : {{include reference="AppWithinMinutes.Content"/}}
     ; &lt;label for="QA.TestClass_0_expectedResult&gt;$doc.displayPrettyName('expectedResult', false, false)&lt;/label&gt;
     : $doc.display('expectedResult')
-    ; &lt;label for="QA.TestClass_0_userType"&gt;$doc.displayPrettyName('userType', false, false)&lt;/label&gt;
-    : $doc.display('userType')
     ; &lt;label for="QA.TestClass_0_wikiType"&gt;$doc.displayPrettyName('wikiType', false, false)&lt;/label&gt;
     : $doc.display('wikiType')
+    ; &lt;label for="QA.TestClass_0_userType"&gt;$doc.displayPrettyName('userType', false, false)&lt;/label&gt;
+    : $doc.display('userType')
     ; &lt;label for="QA.TestClass_0_automated"&gt;$doc.displayPrettyName('automated', false, false)&lt;/label&gt;
     : $doc.display('automated')
-    ; &lt;label for="QA.TestClass_0_jira"&gt;$doc.displayPrettyName('jira', false, false)&lt;/label&gt;
-    : $doc.display('jira')
-    ; &lt;label for="QA.TestClass_0_tests"&gt;$doc.displayPrettyName('tests', false, false)&lt;/label&gt;
-    : $doc.display('tests')
-    ; &lt;label for="QA.TestClass_0_notes"&gt;$doc.displayPrettyName('notes', false, false)&lt;/label&gt;
-    : $doc.display('notes')
     ; &lt;label for="QA.TestClass_0_deprecated"&gt;$doc.displayPrettyName('deprecated', false, false)&lt;/label&gt;
     : $doc.display('deprecated')
+    ; &lt;label for="QA.TestClass_0_automatedLinkSourceCode"&gt;$doc.displayPrettyName('automatedLinkSourceCode', false, false)&lt;/label&gt;
+    : $doc.display('automatedLinkSourceCode')
   )))
   {{/html}}
 #end
@@ -84,9 +80,16 @@
       $doc.display('expectedResult')
     )))
 
-    == $doc.displayPrettyName('automated', false, false) ==
-    $doc.display('automated')
-
+    ## Display automated status from QA.AutomatedTestStatusClass
+    ## Old code:
+    ## == $doc.displayPrettyName('automated', false, false) ==
+    ## $doc.display('automated')
+    #set ($automatedObject = $doc.getObject('QA.AutomatedTestStatusClass'))
+    #if ($automatedObject)
+      == $doc.displayPrettyName('status', false, false, $automatedObject) ==
+      $doc.display('status', $automatedObject)
+    #end
+    
     == Results ==
     #set($discard = $xwiki.ssx.use("QA.WebHome"))
     #set($discard = $xwiki.jsx.use("QA.WebHome" ,{'minify':false,'defer':false}))

--- a/src/main/resources/QA/TestSheet.xml
+++ b/src/main/resources/QA/TestSheet.xml
@@ -51,12 +51,19 @@
     : $doc.display('wikiType')
     ; &lt;label for="QA.TestClass_0_userType"&gt;$doc.displayPrettyName('userType', false, false)&lt;/label&gt;
     : $doc.display('userType')
-    ; &lt;label for="QA.TestClass_0_automated"&gt;$doc.displayPrettyName('automated', false, false)&lt;/label&gt;
-    : $doc.display('automated')
+    #set ($automatedObject = $doc.getObject('QA.AutomatedTestStatusClass'))
+    #if ($automatedObject)
+      ; &lt;label for="QA.AutomatedTestStatusClass_0_status"&gt;$doc.displayPrettyName('status', false, false, $automatedObject)&lt;/label&gt;
+      : $doc.display('status')
+      ; &lt;label for="QA.AutomatedTestStatusClass_0_jira"&gt;$doc.displayPrettyName('jira', false, false, $automatedObject)&lt;/label&gt;
+      : $doc.display('jira')
+      ; &lt;label for="QA.AutomatedTestStatusClass_0_tests"&gt;$doc.displayPrettyName('tests', false, false, $automatedObject)&lt;/label&gt;
+      : $doc.display('tests')
+      ; &lt;label for="QA.AutomatedTestStatusClass_0_notes"&gt;$doc.displayPrettyName('notes', false, false, $automatedObject)&lt;/label&gt;
+      : $doc.display('notes')
+    #end
     ; &lt;label for="QA.TestClass_0_deprecated"&gt;$doc.displayPrettyName('deprecated', false, false)&lt;/label&gt;
     : $doc.display('deprecated')
-    ; &lt;label for="QA.TestClass_0_automatedLinkSourceCode"&gt;$doc.displayPrettyName('automatedLinkSourceCode', false, false)&lt;/label&gt;
-    : $doc.display('automatedLinkSourceCode')
   )))
   {{/html}}
 #end
@@ -84,10 +91,28 @@
     ## Old code:
     ## == $doc.displayPrettyName('automated', false, false) ==
     ## $doc.display('automated')
+    == $doc.displayPrettyName('wikiType', false, false) ==
+    $doc.display('wikiType')
+    == $doc.displayPrettyName('userType', false, false) ==
+    $doc.display('userType')
     #set ($automatedObject = $doc.getObject('QA.AutomatedTestStatusClass'))
     #if ($automatedObject)
       == $doc.displayPrettyName('status', false, false, $automatedObject) ==
       $doc.display('status', $automatedObject)
+      == $doc.displayPrettyName('jira', false, false, $automatedObject) ==
+      $doc.display('jira', $automatedObject)
+      == $doc.displayPrettyName('tests', false, false, $automatedObject) ==
+      $doc.display('tests', $automatedObject)
+      == $doc.displayPrettyName('notes', false, false, $automatedObject) ==
+      $doc.display('notes', $automatedObject)
+    #else
+
+      {{warning cssClass="add-automatedclass-xobject-container"}}
+        This page is missing an Automation XObject.
+        #if ($hasEdit)
+          [[Click here to create one&gt;&gt;$services.rendering.escape($doc.fullName, 'xwiki/2.1')]]
+        #end
+      {{/warning}}
     #end
     
     == Results ==
@@ -221,6 +246,24 @@
   shortcut.add("Alt+Shift+q", function() {
     let submitButton = $('span.wikilink&gt;a[href$="sheet=QA.ExecutionAddSheet"]')[0];
     submitButton.click();
+  });
+  $('.add-automatedclass-xobject-container a').on('click', function (event) {
+    event.preventDefault();
+    fetch(XWiki.currentDocument.getRestURL('objects'), {
+      method: "POST",
+      body: "className=QA.AutomatedTestStatusClass",
+      headers: {
+        "Content-type": "application/x-www-form-urlencoded"
+      }
+    }).then((response) =&gt; {
+      if (!response.ok) {
+        throw response;
+      }
+      window.location.reload();
+    }).catch((error) =&gt; {
+      console.error('Failed to add the QA.AutomatedTestStatusClass object', error);
+      var notification = new XWiki.widgets.Notification('Failed to add the QA.AutomatedTestStatusClass object', 'error');
+    });
   });
 });</code>
     </property>

--- a/src/main/resources/QA/TestSheet.xml
+++ b/src/main/resources/QA/TestSheet.xml
@@ -44,20 +44,7 @@
   {{html wiki="true"}}
   (% class = "xform" %)(((
     ; &lt;label for="content"&gt;Steps to reproduce&lt;/label&gt;
-    : {{html clean="false"}}
-      #if (!$useWysiwygEditor)
-        &lt;div id="xwikieditcontentinner"&gt;
-          ## The tool bar may have an entry to insert an HTML macro. Make sure it doesn't break the HTML macro we are currently in.
-          #set ($toolBar = "#template('simpleedittoolbar.vm')")
-          $!toolBar.replace('{{', '&amp;#123;&amp;#123;')
-      #end
-      $xwiki.getTextArea($tdoc.content)
-      #if ($useWysiwygEditor)
-        #wysiwyg_editProperty($tdoc "content" true)
-      #else
-        &lt;/div&gt;
-      #end
-      {{/html}}
+    : {{include reference="AppWithinMinutes.Content"/}}
     ; &lt;label for="QA.TestClass_0_expectedResult&gt;$doc.displayPrettyName('expectedResult', false, false)&lt;/label&gt;
     : $doc.display('expectedResult')
     ; &lt;label for="QA.TestClass_0_wikiType"&gt;$doc.displayPrettyName('wikiType', false, false)&lt;/label&gt;

--- a/src/main/resources/QA/TestSheet.xml
+++ b/src/main/resources/QA/TestSheet.xml
@@ -47,16 +47,20 @@
     : {{include reference="AppWithinMinutes.Content"/}}
     ; &lt;label for="QA.TestClass_0_expectedResult&gt;$doc.displayPrettyName('expectedResult', false, false)&lt;/label&gt;
     : $doc.display('expectedResult')
-    ; &lt;label for="QA.TestClass_0_wikiType"&gt;$doc.displayPrettyName('wikiType', false, false)&lt;/label&gt;
-    : $doc.display('wikiType')
     ; &lt;label for="QA.TestClass_0_userType"&gt;$doc.displayPrettyName('userType', false, false)&lt;/label&gt;
     : $doc.display('userType')
+    ; &lt;label for="QA.TestClass_0_wikiType"&gt;$doc.displayPrettyName('wikiType', false, false)&lt;/label&gt;
+    : $doc.display('wikiType')
     ; &lt;label for="QA.TestClass_0_automated"&gt;$doc.displayPrettyName('automated', false, false)&lt;/label&gt;
     : $doc.display('automated')
+    ; &lt;label for="QA.TestClass_0_jira"&gt;$doc.displayPrettyName('jira', false, false)&lt;/label&gt;
+    : $doc.display('jira')
+    ; &lt;label for="QA.TestClass_0_tests"&gt;$doc.displayPrettyName('tests', false, false)&lt;/label&gt;
+    : $doc.display('tests')
+    ; &lt;label for="QA.TestClass_0_notes"&gt;$doc.displayPrettyName('notes', false, false)&lt;/label&gt;
+    : $doc.display('notes')
     ; &lt;label for="QA.TestClass_0_deprecated"&gt;$doc.displayPrettyName('deprecated', false, false)&lt;/label&gt;
     : $doc.display('deprecated')
-    ; &lt;label for="QA.TestClass_0_automatedLinkSourceCode"&gt;$doc.displayPrettyName('automatedLinkSourceCode', false, false)&lt;/label&gt;
-    : $doc.display('automatedLinkSourceCode')
   )))
   {{/html}}
 #end
@@ -80,16 +84,9 @@
       $doc.display('expectedResult')
     )))
 
-    ## Display automated status from QA.AutomatedTestStatusClass
-    ## Old code:
-    ## == $doc.displayPrettyName('automated', false, false) ==
-    ## $doc.display('automated')
-    #set ($automatedObject = $doc.getObject('QA.AutomatedTestStatusClass'))
-    #if ($automatedObject)
-      == $doc.displayPrettyName('status', false, false, $automatedObject) ==
-      $doc.display('status', $automatedObject)
-    #end
-    
+    == $doc.displayPrettyName('automated', false, false) ==
+    $doc.display('automated')
+
     == Results ==
     #set($discard = $xwiki.ssx.use("QA.WebHome"))
     #set($discard = $xwiki.jsx.use("QA.WebHome" ,{'minify':false,'defer':false}))

--- a/src/main/resources/QA/TestSheet.xml
+++ b/src/main/resources/QA/TestSheet.xml
@@ -91,20 +91,10 @@
     ## Old code:
     ## == $doc.displayPrettyName('automated', false, false) ==
     ## $doc.display('automated')
-    == $doc.displayPrettyName('wikiType', false, false) ==
-    $doc.display('wikiType')
-    == $doc.displayPrettyName('userType', false, false) ==
-    $doc.display('userType')
     #set ($automatedObject = $doc.getObject('QA.AutomatedTestStatusClass'))
     #if ($automatedObject)
       == $doc.displayPrettyName('status', false, false, $automatedObject) ==
       $doc.display('status', $automatedObject)
-      == $doc.displayPrettyName('jira', false, false, $automatedObject) ==
-      $doc.display('jira', $automatedObject)
-      == $doc.displayPrettyName('tests', false, false, $automatedObject) ==
-      $doc.display('tests', $automatedObject)
-      == $doc.displayPrettyName('notes', false, false, $automatedObject) ==
-      $doc.display('notes', $automatedObject)
     #else
 
       {{warning cssClass="add-automatedclass-xobject-container"}}

--- a/src/main/resources/QA/TestSpaceWebHomeTemplate.xml
+++ b/src/main/resources/QA/TestSpaceWebHomeTemplate.xml
@@ -41,7 +41,7 @@
 #set($discard = $xwiki.ssx.use("QA.WebHome"))
 #set($discard = $xwiki.jsx.use("QA.WebHome" ,{'minify':false,'defer':false}))
 #set($columns = ['deprecated', 'doc.title', 'wikiType', 'userType', 'product', 'browsers', 'databases',
-    'servletContainers', 'javas', 'distributions', 'automated'])
+    'servletContainers', 'javas', 'distributions', 'status'])
 #set($columnsProperties = {
   'deprecated'    :{'type': 'list', 'class': 'QA.TestClass'},
   'doc.title'     :{'type': 'text', 'link': 'view', 'size': 10, 'filterable': true, 'sortable': true},
@@ -54,6 +54,7 @@
   'javas'      :{'type': 'text', 'html': true, 'filterable': false, 'sortable': false},
   'distributions'      :{'type': 'text', 'html': true, 'filterable': false, 'sortable': false},
   'automated'     :{'type': 'list', 'class': 'QA.TestClass'},
+  'status'        :{'type': 'list', 'class': 'QA.AutomatedTestStatusClass'},
   '_actions'      :{'actions': [
     {
       'id': 'runTest',

--- a/src/main/resources/QA/TestTemplate.xml
+++ b/src/main/resources/QA/TestTemplate.xml
@@ -62,34 +62,20 @@
         <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>automated</name>
-        <number>4</number>
-        <picker>0</picker>
-        <prettyName>Automated</prettyName>
+        <number>3</number>
+        <picker>1</picker>
+        <prettyName>Automation Status</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
-        <separators> ,|</separators>
+        <separators>|, </separators>
         <size>1</size>
-        <sort>none</sort>
+        <sort/>
         <unmodifiable>0</unmodifiable>
         <validationMessage/>
         <validationRegExp/>
-        <values>yes=Yes|no=No</values>
+        <values>automated=Automated|notAutomatable=Not Automatable|needsTest=Needs Automated Test</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </automated>
-      <automatedLinkSourceCode>
-        <customDisplay/>
-        <disabled>0</disabled>
-        <hint/>
-        <name>automatedLinkSourceCode</name>
-        <number>3</number>
-        <picker>0</picker>
-        <prettyName>Automated Link Source Code</prettyName>
-        <size>30</size>
-        <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </automatedLinkSourceCode>
       <deprecated>
         <cache>0</cache>
         <customDisplay/>
@@ -101,7 +87,7 @@
         <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>deprecated</name>
-        <number>5</number>
+        <number>7</number>
         <picker>0</picker>
         <prettyName>Deprecated</prettyName>
         <relationalStorage>0</relationalStorage>
@@ -122,9 +108,10 @@
         <editor>---</editor>
         <hint/>
         <name>expectedResult</name>
-        <number>2</number>
+        <number>1</number>
         <picker>0</picker>
         <prettyName>Expected result</prettyName>
+        <restricted>0</restricted>
         <rows>5</rows>
         <size>40</size>
         <unmodifiable>0</unmodifiable>
@@ -132,6 +119,56 @@
         <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
       </expectedResult>
+      <jira>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <hint/>
+        <name>jira</name>
+        <number>4</number>
+        <picker>1</picker>
+        <prettyName>JIRA link for automating the test</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </jira>
+      <notes>
+        <contenttype>---</contenttype>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <editor>---</editor>
+        <hint/>
+        <name>notes</name>
+        <number>6</number>
+        <picker>1</picker>
+        <prettyName>Notes</prettyName>
+        <restricted>0</restricted>
+        <rows>5</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </notes>
+      <tests>
+        <contenttype>---</contenttype>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <editor>---</editor>
+        <hint/>
+        <name>tests</name>
+        <number>5</number>
+        <picker>1</picker>
+        <prettyName>List of automated GitHub test links</prettyName>
+        <restricted>0</restricted>
+        <rows>5</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </tests>
       <userType>
         <cache>0</cache>
         <customDisplay/>
@@ -143,7 +180,7 @@
         <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>userType</name>
-        <number>4</number>
+        <number>1</number>
         <picker>0</picker>
         <prettyName>User Type</prettyName>
         <relationalStorage>0</relationalStorage>
@@ -160,11 +197,15 @@
       <wikiType>
         <cache>0</cache>
         <customDisplay/>
+        <defaultValue/>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText/>
+        <hint/>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>wikiType</name>
-        <number>5</number>
+        <number>2</number>
         <picker>0</picker>
         <prettyName>Wiki Type</prettyName>
         <relationalStorage>0</relationalStorage>
@@ -190,6 +231,15 @@
     </property>
     <property>
       <expectedResult/>
+    </property>
+    <property>
+      <jira/>
+    </property>
+    <property>
+      <notes/>
+    </property>
+    <property>
+      <tests/>
     </property>
     <property>
       <userType>admin</userType>

--- a/src/main/resources/QA/TestTemplate.xml
+++ b/src/main/resources/QA/TestTemplate.xml
@@ -62,20 +62,34 @@
         <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>automated</name>
-        <number>3</number>
-        <picker>1</picker>
-        <prettyName>Automation Status</prettyName>
+        <number>4</number>
+        <picker>0</picker>
+        <prettyName>Automated</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
-        <separators>|, </separators>
+        <separators> ,|</separators>
         <size>1</size>
-        <sort/>
+        <sort>none</sort>
         <unmodifiable>0</unmodifiable>
         <validationMessage/>
         <validationRegExp/>
-        <values>automated=Automated|notAutomatable=Not Automatable|needsTest=Needs Automated Test</values>
+        <values>yes=Yes|no=No</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </automated>
+      <automatedLinkSourceCode>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <hint/>
+        <name>automatedLinkSourceCode</name>
+        <number>3</number>
+        <picker>0</picker>
+        <prettyName>Automated Link Source Code</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </automatedLinkSourceCode>
       <deprecated>
         <cache>0</cache>
         <customDisplay/>
@@ -87,7 +101,7 @@
         <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>deprecated</name>
-        <number>7</number>
+        <number>5</number>
         <picker>0</picker>
         <prettyName>Deprecated</prettyName>
         <relationalStorage>0</relationalStorage>
@@ -108,10 +122,9 @@
         <editor>---</editor>
         <hint/>
         <name>expectedResult</name>
-        <number>1</number>
+        <number>2</number>
         <picker>0</picker>
         <prettyName>Expected result</prettyName>
-        <restricted>0</restricted>
         <rows>5</rows>
         <size>40</size>
         <unmodifiable>0</unmodifiable>
@@ -119,56 +132,6 @@
         <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
       </expectedResult>
-      <jira>
-        <customDisplay/>
-        <disabled>0</disabled>
-        <hint/>
-        <name>jira</name>
-        <number>4</number>
-        <picker>1</picker>
-        <prettyName>JIRA link for automating the test</prettyName>
-        <size>30</size>
-        <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </jira>
-      <notes>
-        <contenttype>---</contenttype>
-        <customDisplay/>
-        <disabled>0</disabled>
-        <editor>---</editor>
-        <hint/>
-        <name>notes</name>
-        <number>6</number>
-        <picker>1</picker>
-        <prettyName>Notes</prettyName>
-        <restricted>0</restricted>
-        <rows>5</rows>
-        <size>40</size>
-        <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
-      </notes>
-      <tests>
-        <contenttype>---</contenttype>
-        <customDisplay/>
-        <disabled>0</disabled>
-        <editor>---</editor>
-        <hint/>
-        <name>tests</name>
-        <number>5</number>
-        <picker>1</picker>
-        <prettyName>List of automated GitHub test links</prettyName>
-        <restricted>0</restricted>
-        <rows>5</rows>
-        <size>40</size>
-        <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
-      </tests>
       <userType>
         <cache>0</cache>
         <customDisplay/>
@@ -180,7 +143,7 @@
         <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>userType</name>
-        <number>1</number>
+        <number>4</number>
         <picker>0</picker>
         <prettyName>User Type</prettyName>
         <relationalStorage>0</relationalStorage>
@@ -197,15 +160,11 @@
       <wikiType>
         <cache>0</cache>
         <customDisplay/>
-        <defaultValue/>
         <disabled>0</disabled>
         <displayType>select</displayType>
-        <freeText/>
-        <hint/>
-        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>wikiType</name>
-        <number>2</number>
+        <number>5</number>
         <picker>0</picker>
         <prettyName>Wiki Type</prettyName>
         <relationalStorage>0</relationalStorage>
@@ -228,15 +187,6 @@
     </property>
     <property>
       <expectedResult/>
-    </property>
-    <property>
-      <jira/>
-    </property>
-    <property>
-      <notes/>
-    </property>
-    <property>
-      <tests/>
     </property>
     <property>
       <userType>admin</userType>

--- a/src/main/resources/QA/TestTemplate.xml
+++ b/src/main/resources/QA/TestTemplate.xml
@@ -221,10 +221,7 @@
       </wikiType>
     </class>
     <property>
-      <automated>no</automated>
-    </property>
-    <property>
-      <automatedLinkSourceCode/>
+      <automated>needsTest</automated>
     </property>
     <property>
       <deprecated>no</deprecated>

--- a/src/main/resources/QA/TestTemplate.xml
+++ b/src/main/resources/QA/TestTemplate.xml
@@ -40,6 +40,109 @@
   <object>
     <name>QA.TestTemplate</name>
     <number>0</number>
+    <className>QA.AutomatedTestStatusClass</className>
+    <guid>766289ee-ec60-4c08-8b0a-c9c51a25b660</guid>
+    <class>
+      <name>QA.AutomatedTestStatusClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <jira>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <hint/>
+        <name>jira</name>
+        <number>2</number>
+        <picker>1</picker>
+        <prettyName>JIRA link for automating the test</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </jira>
+      <notes>
+        <contenttype>---</contenttype>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <editor>---</editor>
+        <hint/>
+        <name>notes</name>
+        <number>4</number>
+        <picker>1</picker>
+        <prettyName>Notes</prettyName>
+        <restricted>0</restricted>
+        <rows>5</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </notes>
+      <status>
+        <cache>0</cache>
+        <customDisplay/>
+        <defaultValue/>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText/>
+        <hint/>
+        <largeStorage>0</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>status</name>
+        <number>1</number>
+        <picker>1</picker>
+        <prettyName>Automation Status</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <sort/>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <values>Automated|Not Automatable|Needs Automated Test</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </status>
+      <tests>
+        <contenttype>---</contenttype>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <editor>---</editor>
+        <hint/>
+        <name>tests</name>
+        <number>3</number>
+        <picker>1</picker>
+        <prettyName>List of automated GitHub test links</prettyName>
+        <restricted>0</restricted>
+        <rows>5</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </tests>
+    </class>
+    <property>
+      <jira/>
+    </property>
+    <property>
+      <notes/>
+    </property>
+    <property>
+      <status/>
+    </property>
+    <property>
+      <tests/>
+    </property>
+  </object>
+  <object>
+    <name>QA.TestTemplate</name>
+    <number>0</number>
     <className>QA.TestClass</className>
     <guid>45e21d85-7448-48c5-bb66-d4b48ef07f34</guid>
     <class>
@@ -180,7 +283,10 @@
       </wikiType>
     </class>
     <property>
-      <automated>needsTest</automated>
+      <automated>no</automated>
+    </property>
+    <property>
+      <automatedLinkSourceCode/>
     </property>
     <property>
       <deprecated>no</deprecated>

--- a/src/main/resources/QA/Translations.xml
+++ b/src/main/resources/QA/Translations.xml
@@ -48,6 +48,7 @@ qaapp.WebHome.LiveTable.servletContainers=Containers
 qaapp.WebHome.LiveTable.javas=Java
 qaapp.WebHome.LiveTable.distributions=Distribution
 qaapp.WebHome.LiveTable.automated=Automated
+qaapp.WebHome.LiveTable.status=Automation Status
 qaapp.WebHome.LiveTable._actions=Action
 qaapp.WebHome.LiveTable.no.tests.execution.found=No test executions found
 qaapp.WebHome.LiveTable._actions.runTest=Run Test

--- a/src/main/resources/QA/WebHome.xml
+++ b/src/main/resources/QA/WebHome.xml
@@ -39,7 +39,7 @@
   <content>{{velocity}}
 #set($discard = $xwiki.ssx.use("QA.WebHome"))
 #set($discard = $xwiki.jsx.use("QA.WebHome" ,{'minify':false,'defer':false}))
-#set($columns = ['deprecated','doc.title', 'doc.space', 'wikiType', 'userType', 'product', 'browsers', 'databases', 'servletContainers', 'javas', 'distributions', 'automated'])
+#set($columns = ['deprecated','doc.title', 'doc.space', 'wikiType', 'userType', 'product', 'browsers', 'databases', 'servletContainers', 'javas', 'distributions', 'status'])
 #set($columnsProperties = {
   'doc.title'      :{'type': 'text', 'link': 'view', 'size': 10, 'filterable': true, 'sortable': true},
   'doc.space'     :{'type': 'text', 'link': 'space', 'size': 10, 'filterable': true, 'sortable': true},
@@ -52,6 +52,7 @@
   'javas'     :{'type': 'text', 'html': true, 'filterable': false, 'sortable': false},
   'distributions'     :{'type': 'text', 'html': true, 'filterable': false, 'sortable': false},
   'automated'     :{'type': 'list', 'class': 'QA.TestClass'},
+  'status'        :{'type': 'list', 'class': 'QA.AutomatedTestStatusClass'},
   'deprecated'     :{'type': 'list', 'class': 'QA.TestClass'}
 })
 #set($options = {


### PR DESCRIPTION
- Added the properties from `QA.AutomatedTestStatusClass` to the Test Sheet edit mode, for easier editing.
- Added script to add missing `QA.AutomatedTestStatusClass` objects in older tests
- Added automation status in live tables
- Fixed a display error in the test description property in edit mode
- Updated the test template to contain a `QA.AutomatedTestStatusClass` object
- Added warning when `QA.AutomatedTestStatusClass` is missing from a test page